### PR TITLE
Devcon workshop - Make your data portable

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
@@ -248,6 +248,16 @@ public interface UserAccountResource {
 			String contentType, String fieldNames)
 		throws Exception;
 
+	public UserAccount postSiteUserAccount(
+			Long siteId, String captchaAnswer, String captchaToken,
+			UserAccount userAccount)
+		throws Exception;
+
+	public Response postSiteUserAccountBatch(
+			Long siteId, String captchaAnswer, String captchaToken,
+			String callbackURL, Object object)
+		throws Exception;
+
 	public Response postSiteUserAccountsPageExportBatch(
 			Long siteId, String search,
 			com.liferay.portal.kernel.search.filter.Filter filter,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-api/src/main/java/com/liferay/headless/admin/user/resource/v1_0/UserAccountResource.java
@@ -147,6 +147,10 @@ public interface UserAccountResource {
 			String externalReferenceCode)
 		throws Exception;
 
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			getUserAccountPermissionsPage(Long userAccountId, String roleNames)
+		throws Exception;
+
 	public Page<UserAccount> getUserAccountsByStatusPage(
 			String status, String search,
 			com.liferay.portal.kernel.search.filter.Filter filter,
@@ -280,6 +284,12 @@ public interface UserAccountResource {
 
 	public UserAccount putUserAccountByExternalReferenceCode(
 			String externalReferenceCode, UserAccount userAccount)
+		throws Exception;
+
+	public Page<com.liferay.portal.vulcan.permission.Permission>
+			putUserAccountPermissionsPage(
+				Long userAccountId,
+				com.liferay.portal.vulcan.permission.Permission[] permissions)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
@@ -426,6 +426,26 @@ public interface UserAccountResource {
 				String fieldNames)
 		throws Exception;
 
+	public UserAccount postSiteUserAccount(
+			Long siteId, String captchaAnswer, String captchaToken,
+			UserAccount userAccount)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postSiteUserAccountHttpResponse(
+			Long siteId, String captchaAnswer, String captchaToken,
+			UserAccount userAccount)
+		throws Exception;
+
+	public void postSiteUserAccountBatch(
+			Long siteId, String captchaAnswer, String captchaToken,
+			String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postSiteUserAccountBatchHttpResponse(
+			Long siteId, String captchaAnswer, String captchaToken,
+			String callbackURL, Object object)
+		throws Exception;
+
 	public void postSiteUserAccountsPageExportBatch(
 			Long siteId, String search, String filterString, String sortString,
 			String callbackURL, String contentType, String fieldNames)
@@ -5341,6 +5361,242 @@ public interface UserAccountResource {
 						"/o/headless-admin-user/v1.0/organizations/{organizationId}/user-accounts/export-batch");
 
 			httpInvoker.path("organizationId", organizationId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public UserAccount postSiteUserAccount(
+				Long siteId, String captchaAnswer, String captchaToken,
+				UserAccount userAccount)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteUserAccountHttpResponse(
+					siteId, captchaAnswer, captchaToken, userAccount);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return UserAccountSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postSiteUserAccountHttpResponse(
+				Long siteId, String captchaAnswer, String captchaToken,
+				UserAccount userAccount)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(userAccount.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (captchaAnswer != null) {
+				httpInvoker.parameter(
+					"captchaAnswer", String.valueOf(captchaAnswer));
+			}
+
+			if (captchaToken != null) {
+				httpInvoker.parameter(
+					"captchaToken", String.valueOf(captchaToken));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-user/v1.0/sites/{siteId}/user-accounts");
+
+			httpInvoker.path("siteId", siteId);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postSiteUserAccountBatch(
+				Long siteId, String captchaAnswer, String captchaToken,
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postSiteUserAccountBatchHttpResponse(
+					siteId, captchaAnswer, captchaToken, callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse postSiteUserAccountBatchHttpResponse(
+				Long siteId, String captchaAnswer, String captchaToken,
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (captchaAnswer != null) {
+				httpInvoker.parameter(
+					"captchaAnswer", String.valueOf(captchaAnswer));
+			}
+
+			if (captchaToken != null) {
+				httpInvoker.parameter(
+					"captchaToken", String.valueOf(captchaToken));
+			}
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-user/v1.0/sites/{siteId}/user-accounts/batch");
+
+			httpInvoker.path("siteId", siteId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-client/src/main/java/com/liferay/headless/admin/user/client/resource/v1_0/UserAccountResource.java
@@ -9,6 +9,7 @@ import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.client.http.HttpInvoker;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
+import com.liferay.headless.admin.user.client.permission.Permission;
 import com.liferay.headless.admin.user.client.problem.Problem;
 import com.liferay.headless.admin.user.client.serdes.v1_0.UserAccountSerDes;
 
@@ -233,6 +234,14 @@ public interface UserAccountResource {
 	public HttpInvoker.HttpResponse
 			getUserAccountByExternalReferenceCodeHttpResponse(
 				String externalReferenceCode)
+		throws Exception;
+
+	public Page<Permission> getUserAccountPermissionsPage(
+			Long userAccountId, String roleNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getUserAccountPermissionsPageHttpResponse(
+			Long userAccountId, String roleNames)
 		throws Exception;
 
 	public Page<UserAccount> getUserAccountsByStatusPage(
@@ -489,6 +498,14 @@ public interface UserAccountResource {
 	public HttpInvoker.HttpResponse
 			putUserAccountByExternalReferenceCodeHttpResponse(
 				String externalReferenceCode, UserAccount userAccount)
+		throws Exception;
+
+	public Page<Permission> putUserAccountPermissionsPage(
+			Long userAccountId, Permission[] permissions)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse putUserAccountPermissionsPageHttpResponse(
+			Long userAccountId, Permission[] permissions)
 		throws Exception;
 
 	public static class Builder {
@@ -3086,6 +3103,118 @@ public interface UserAccountResource {
 						"/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Permission> getUserAccountPermissionsPage(
+				Long userAccountId, String roleNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getUserAccountPermissionsPageHttpResponse(
+					userAccountId, roleNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, Permission::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getUserAccountPermissionsPageHttpResponse(
+					Long userAccountId, String roleNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (roleNames != null) {
+				httpInvoker.parameter("roleNames", String.valueOf(roleNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}/permissions");
+
+			httpInvoker.path("userAccountId", userAccountId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -6123,6 +6252,122 @@ public interface UserAccountResource {
 						"/o/headless-admin-user/v1.0/user-accounts/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<Permission> putUserAccountPermissionsPage(
+				Long userAccountId, Permission[] permissions)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putUserAccountPermissionsPageHttpResponse(
+					userAccountId, permissions);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, Permission::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putUserAccountPermissionsPageHttpResponse(
+					Long userAccountId, Permission[] permissions)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			List<String> values = new ArrayList<>();
+
+			for (Permission permissionValue : permissions) {
+				values.add(String.valueOf(permissionValue));
+			}
+
+			httpInvoker.body(values.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-admin-user/v1.0/user-accounts/{userAccountId}/permissions");
+
+			httpInvoker.path("userAccountId", userAccountId);
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-config.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-config.yaml
@@ -7,5 +7,6 @@ application:
 author: Javier Gamarra
 clientDir: ../headless-admin-user-client/src/main/java
 compatibilityVersion: 13
+generatePermissions: true
 javaEEPackage: jakarta
 testDir: ../headless-admin-user-test/src/testIntegration/java

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -7529,6 +7529,58 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/Ticket"
             tags: ["Ticket"]
+    "/user-accounts/{userAccountId}/permissions":
+        get:
+            description:
+                Retrieves the user account permissions.
+            operationId: getUserAccountPermissionsPage
+            parameters:
+                -   in: path
+                    name: userAccountId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: fields
+                    schema:
+                        type: string
+                -   in: query
+                    name: restrictFields
+                    schema:
+                        type: string
+                -   in: query
+                    name: roleNames
+                    schema:
+                        type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["UserAccount"]
+        put:
+            # @review
+            description:
+                Overrides the userAccount permissions
+            operationId: putUserAccountPermissionsPage
+            parameters:
+                -   in: path
+                    name: userAccountId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+            requestBody:
+                content:
+                    application/json: {}
+                    application/xml: {}
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["UserAccount"]
     "/user-accounts/{userAccountId}/phones":
         get:
             description:

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -6944,6 +6944,45 @@ paths:
                                     $ref: "#/components/schemas/UserAccount"
                                 type: array
             tags: ["UserAccount"]
+        post:
+            description:
+                Creates a user account associated to a specific site.
+            operationId: postSiteUserAccount
+            parameters:
+                -   in: path
+                    name: siteId
+                    required: true
+                    schema:
+                        format: int64
+                        type: integer
+                -   in: query
+                    name: captchaAnswer
+                    required: false
+                    schema:
+                        type: string
+                -   in: query
+                    name: captchaToken
+                    required: false
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/UserAccount"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/UserAccount"
+            responses:
+                201:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/UserAccount"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/UserAccount"
+            tags: ["UserAccount"]
     "/sites/{siteId}/user-accounts/{userAccountId}/segments":
         get:
             # @review

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
@@ -2719,6 +2719,41 @@ public class Mutation {
 					callbackURL, contentType, fieldNames));
 	}
 
+	@GraphQLField(
+		description = "Creates a user account associated to a specific site."
+	)
+	public UserAccount createSiteUserAccount(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("captchaAnswer") String captchaAnswer,
+			@GraphQLName("captchaToken") String captchaToken,
+			@GraphQLName("userAccount") UserAccount userAccount)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_userAccountResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			userAccountResource -> userAccountResource.postSiteUserAccount(
+				Long.valueOf(siteKey), captchaAnswer, captchaToken,
+				userAccount));
+	}
+
+	@GraphQLField
+	public Response createSiteUserAccountBatch(
+			@GraphQLName("siteKey") @NotEmpty String siteKey,
+			@GraphQLName("captchaAnswer") String captchaAnswer,
+			@GraphQLName("captchaToken") String captchaToken,
+			@GraphQLName("callbackURL") String callbackURL,
+			@GraphQLName("object") Object object)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_userAccountResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			userAccountResource -> userAccountResource.postSiteUserAccountBatch(
+				Long.valueOf(siteKey), captchaAnswer, captchaToken, callbackURL,
+				object));
+	}
+
 	@GraphQLField
 	public Response createSiteUserAccountsPageExportBatch(
 			@GraphQLName("siteKey") @NotEmpty String siteKey,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/mutation/v1_0/Mutation.java
@@ -2850,6 +2850,27 @@ public class Mutation {
 					externalReferenceCode, userAccount));
 	}
 
+	@GraphQLField(description = "Overrides the userAccount permissions")
+	public java.util.Collection<com.liferay.portal.vulcan.permission.Permission>
+			updateUserAccountPermissionsPage(
+				@GraphQLName("userAccountId") Long userAccountId,
+				@GraphQLName("permissions")
+					com.liferay.portal.vulcan.permission.Permission[]
+						permissions)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_userAccountResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			userAccountResource -> {
+				Page paginationPage =
+					userAccountResource.putUserAccountPermissionsPage(
+						userAccountId, permissions);
+
+				return paginationPage.getItems();
+			});
+	}
+
 	@GraphQLField
 	public boolean deleteUserGroup(@GraphQLName("userGroupId") Long userGroupId)
 		throws Exception {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/query/v1_0/Query.java
@@ -1938,6 +1938,25 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {userAccountPermissions(roleNames: ___, userAccountId: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
+	 */
+	@GraphQLField(description = "Retrieves the user account permissions.")
+	public UserAccountPage userAccountPermissions(
+			@GraphQLName("userAccountId") Long userAccountId,
+			@GraphQLName("roleNames") String roleNames)
+		throws Exception {
+
+		return _applyComponentServiceObjects(
+			_userAccountResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			userAccountResource -> new UserAccountPage(
+				userAccountResource.getUserAccountPermissionsPage(
+					userAccountId, roleNames)));
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {userAccountsByStatus(filter: ___, page: ___, pageSize: ___, search: ___, sorts: ___, status: ___){items {__}, page, pageSize, totalCount}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -908,6 +908,16 @@ public class ServletDataImpl implements ServletData {
 							UserAccountResourceImpl.class,
 							"postOrganizationUserAccountsPageExportBatch"));
 					put(
+						"mutation#createSiteUserAccount",
+						new ObjectValuePair<>(
+							UserAccountResourceImpl.class,
+							"postSiteUserAccount"));
+					put(
+						"mutation#createSiteUserAccountBatch",
+						new ObjectValuePair<>(
+							UserAccountResourceImpl.class,
+							"postSiteUserAccountBatch"));
+					put(
 						"mutation#createSiteUserAccountsPageExportBatch",
 						new ObjectValuePair<>(
 							UserAccountResourceImpl.class,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -946,6 +946,11 @@ public class ServletDataImpl implements ServletData {
 							UserAccountResourceImpl.class,
 							"putUserAccountByExternalReferenceCode"));
 					put(
+						"mutation#updateUserAccountPermissionsPage",
+						new ObjectValuePair<>(
+							UserAccountResourceImpl.class,
+							"putUserAccountPermissionsPage"));
+					put(
 						"mutation#deleteUserGroup",
 						new ObjectValuePair<>(
 							UserGroupResourceImpl.class, "deleteUserGroup"));
@@ -1433,6 +1438,11 @@ public class ServletDataImpl implements ServletData {
 						new ObjectValuePair<>(
 							UserAccountResourceImpl.class,
 							"getUserAccountByExternalReferenceCode"));
+					put(
+						"query#userAccountPermissions",
+						new ObjectValuePair<>(
+							UserAccountResourceImpl.class,
+							"getUserAccountPermissionsPage"));
 					put(
 						"query#userAccountsByStatus",
 						new ObjectValuePair<>(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -2381,6 +2381,147 @@ public abstract class BaseUserAccountResourceImpl
 		).build();
 	}
 
+	protected abstract UserAccount doPostSiteUserAccount(
+			Long siteId, String captchaAnswer, String captchaToken,
+			UserAccount userAccount)
+		throws Exception;
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/sites/{siteId}/user-accounts' -d $'{"additionalName": ___, "alternateName": ___, "birthDate": ___, "currentPassword": ___, "customFields": ___, "emailAddress": ___, "externalReferenceCode": ___, "familyName": ___, "gender": ___, "givenName": ___, "honorificPrefix": ___, "honorificSuffix": ___, "id": ___, "imageExternalReferenceCode": ___, "imageId": ___, "jobTitle": ___, "languageId": ___, "password": ___, "permissions": ___, "status": ___, "userAccountContactInformation": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Creates a user account associated to a specific site."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "captchaAnswer"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "captchaToken"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "UserAccount")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/sites/{siteId}/user-accounts")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public final UserAccount postSiteUserAccount(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("captchaAnswer")
+			String captchaAnswer,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("captchaToken")
+			String captchaToken,
+			UserAccount userAccount)
+		throws Exception {
+
+		Permission[] permissions = userAccount.getPermissions();
+
+		UserAccount postUserAccount = doPostSiteUserAccount(
+			siteId, captchaAnswer, captchaToken, userAccount);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage = putUserAccountPermissionsPage(
+				postUserAccount.getId(), permissions);
+
+			postUserAccount.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postUserAccount;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/sites/{siteId}/user-accounts/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "captchaAnswer"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "captchaToken"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "UserAccount")}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path("/sites/{siteId}/user-accounts/batch")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postSiteUserAccountBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("siteId")
+			Long siteId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("captchaAnswer")
+			String captchaAnswer,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("captchaToken")
+			String captchaToken,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				UserAccount.class.getName(), callbackURL, null, object)
+		).build();
+	}
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -2982,6 +3123,12 @@ public abstract class BaseUserAccountResourceImpl
 						_parseLong((String)parameters.get("accountId")),
 						userAccount);
 			}
+			else if (parameters.containsKey("siteId")) {
+				userAccountUnsafeFunction = userAccount -> postSiteUserAccount(
+					(Long)parameters.get("siteId"),
+					(String)parameters.get("captchaAnswer"),
+					(String)parameters.get("captchaToken"), userAccount);
+			}
 			else if (parameters.containsKey("externalReferenceCode")) {
 				userAccountUnsafeFunction =
 					userAccount ->
@@ -3016,6 +3163,13 @@ public abstract class BaseUserAccountResourceImpl
 						if (parameters.containsKey("accountId")) {
 							persistedUserAccount = postAccountUserAccount(
 								_parseLong((String)parameters.get("accountId")),
+								userAccount);
+						}
+						else if (parameters.containsKey("siteId")) {
+							persistedUserAccount = postSiteUserAccount(
+								(Long)parameters.get("siteId"),
+								(String)parameters.get("captchaAnswer"),
+								(String)parameters.get("captchaToken"),
 								userAccount);
 						}
 						else if (parameters.containsKey(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/BaseUserAccountResourceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.headless.admin.user.internal.resource.v1_0;
 
+import com.liferay.headless.admin.user.dto.v1_0.Role;
 import com.liferay.headless.admin.user.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.resource.v1_0.UserAccountResource;
 import com.liferay.petra.function.UnsafeBiConsumer;
@@ -13,11 +14,22 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.NoSuchModelException;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Resource;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.PermissionServiceUtil;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.permission.ModelPermissions;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -34,9 +46,12 @@ import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
 import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.crud.VulcanCRUDItemDelegate;
+import com.liferay.portal.vulcan.fields.NestedFieldsSupplier;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
+import com.liferay.portal.vulcan.permission.Permission;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
@@ -56,6 +71,8 @@ import java.io.Serializable;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -556,6 +573,13 @@ public abstract class BaseUserAccountResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	protected abstract Page<UserAccount> doGetAccountUserAccountsPage(
+			Long accountId, String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -599,7 +623,7 @@ public abstract class BaseUserAccountResourceImpl
 	@jakarta.ws.rs.Path("/accounts/{accountId}/user-accounts")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<UserAccount> getAccountUserAccountsPage(
+	public final Page<UserAccount> getAccountUserAccountsPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("accountId")
@@ -614,7 +638,27 @@ public abstract class BaseUserAccountResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<UserAccount> userAccountsPage = doGetAccountUserAccountsPage(
+			accountId, search, filter, pagination, sorts);
+
+		for (UserAccount userAccount : userAccountsPage.getItems()) {
+			userAccount.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getUserAccountPermissionsPage(
+								userAccount.getId(), null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return userAccountsPage;
 	}
 
 	/**
@@ -700,6 +744,13 @@ public abstract class BaseUserAccountResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	protected abstract Page<UserAccount> doGetOrganizationUserAccountsPage(
+			String organizationId, String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -743,7 +794,7 @@ public abstract class BaseUserAccountResourceImpl
 	@jakarta.ws.rs.Path("/organizations/{organizationId}/user-accounts")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<UserAccount> getOrganizationUserAccountsPage(
+	public final Page<UserAccount> getOrganizationUserAccountsPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("organizationId")
@@ -758,7 +809,27 @@ public abstract class BaseUserAccountResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<UserAccount> userAccountsPage = doGetOrganizationUserAccountsPage(
+			organizationId, search, filter, pagination, sorts);
+
+		for (UserAccount userAccount : userAccountsPage.getItems()) {
+			userAccount.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getUserAccountPermissionsPage(
+								userAccount.getId(), null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return userAccountsPage;
 	}
 
 	/**
@@ -864,6 +935,13 @@ public abstract class BaseUserAccountResourceImpl
 		return false;
 	}
 
+	protected abstract Page<UserAccount> doGetSiteUserAccountsPage(
+			Long siteId, String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -907,7 +985,7 @@ public abstract class BaseUserAccountResourceImpl
 	@jakarta.ws.rs.Path("/sites/{siteId}/user-accounts")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<UserAccount> getSiteUserAccountsPage(
+	public final Page<UserAccount> getSiteUserAccountsPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("siteId")
@@ -922,8 +1000,31 @@ public abstract class BaseUserAccountResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<UserAccount> userAccountsPage = doGetSiteUserAccountsPage(
+			siteId, search, filter, pagination, sorts);
+
+		for (UserAccount userAccount : userAccountsPage.getItems()) {
+			userAccount.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getUserAccountPermissionsPage(
+								userAccount.getId(), null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return userAccountsPage;
 	}
+
+	protected abstract UserAccount doGetUserAccount(Long userAccountId)
+		throws Exception;
 
 	/**
 	 * Invoke this method with the command line:
@@ -948,14 +1049,31 @@ public abstract class BaseUserAccountResourceImpl
 	@jakarta.ws.rs.Path("/user-accounts/{userAccountId}")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public UserAccount getUserAccount(
+	public final UserAccount getUserAccount(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("userAccountId")
 			Long userAccountId)
 		throws Exception {
 
-		return new UserAccount();
+		UserAccount getUserAccount = doGetUserAccount(userAccountId);
+
+		getUserAccount.setPermissions(
+			() -> NestedFieldsSupplier.supply(
+				"permissions",
+				nestedField -> {
+					Page<Permission> permissionsPage =
+						getUserAccountPermissionsPage(
+							getUserAccount.getId(), null);
+
+					Collection<Permission> permissions =
+						permissionsPage.getItems();
+
+					return permissions.toArray(
+						new Permission[permissions.size()]);
+				}));
+
+		return getUserAccount;
 	}
 
 	/**
@@ -988,6 +1106,10 @@ public abstract class BaseUserAccountResourceImpl
 		return new UserAccount();
 	}
 
+	protected abstract UserAccount doGetUserAccountByExternalReferenceCode(
+			String externalReferenceCode)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -1010,14 +1132,101 @@ public abstract class BaseUserAccountResourceImpl
 	)
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public UserAccount getUserAccountByExternalReferenceCode(
+	public final UserAccount getUserAccountByExternalReferenceCode(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("externalReferenceCode")
 			String externalReferenceCode)
 		throws Exception {
 
-		return new UserAccount();
+		UserAccount getUserAccount = doGetUserAccountByExternalReferenceCode(
+			externalReferenceCode);
+
+		getUserAccount.setPermissions(
+			() -> NestedFieldsSupplier.supply(
+				"permissions",
+				nestedField -> {
+					Page<Permission> permissionsPage =
+						getUserAccountPermissionsPage(
+							getUserAccount.getId(), null);
+
+					Collection<Permission> permissions =
+						permissionsPage.getItems();
+
+					return permissions.toArray(
+						new Permission[permissions.size()]);
+				}));
+
+		return getUserAccount;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/{userAccountId}/permissions'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Retrieves the user account permissions."
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "userAccountId"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "restrictFields"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "roleNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "UserAccount")}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/user-accounts/{userAccountId}/permissions")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Permission> getUserAccountPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("userAccountId")
+			Long userAccountId,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("roleNames")
+			String roleNames)
+		throws Exception {
+
+		Long groupId = getPermissionCheckerGroupId(userAccountId);
+		Long resourceId = getPermissionCheckerResourceId(userAccountId);
+		String resourceName = getPermissionCheckerResourceName(userAccountId);
+
+		PermissionServiceUtil.checkPermission(
+			groupId, resourceName, resourceId);
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS, resourceId,
+					"getUserAccountPermissionsPage", null, resourceName,
+					groupId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS, resourceId,
+					"putUserAccountPermissionsPage", null, resourceName,
+					groupId)
+			).build(),
+			resourceId, resourceName, roleNames);
 	}
 
 	/**
@@ -1078,6 +1287,13 @@ public abstract class BaseUserAccountResourceImpl
 		return Page.of(Collections.emptyList());
 	}
 
+	protected abstract Page<UserAccount> doGetUserAccountsPage(
+			String search,
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -1117,7 +1333,7 @@ public abstract class BaseUserAccountResourceImpl
 	@jakarta.ws.rs.Path("/user-accounts")
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public Page<UserAccount> getUserAccountsPage(
+	public final Page<UserAccount> getUserAccountsPage(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("search")
 			String search,
@@ -1128,7 +1344,27 @@ public abstract class BaseUserAccountResourceImpl
 				sorts)
 		throws Exception {
 
-		return Page.of(Collections.emptyList());
+		Page<UserAccount> userAccountsPage = doGetUserAccountsPage(
+			search, filter, pagination, sorts);
+
+		for (UserAccount userAccount : userAccountsPage.getItems()) {
+			userAccount.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Page<Permission> permissionsPage =
+							getUserAccountPermissionsPage(
+								userAccount.getId(), null);
+
+						Collection<Permission> permissions =
+							permissionsPage.getItems();
+
+						return permissions.toArray(
+							new Permission[permissions.size()]);
+					}));
+		}
+
+		return userAccountsPage;
 	}
 
 	/**
@@ -1644,6 +1880,10 @@ public abstract class BaseUserAccountResourceImpl
 		throws Exception {
 	}
 
+	protected abstract UserAccount doPostAccountUserAccount(
+			Long accountId, UserAccount userAccount)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -1668,7 +1908,7 @@ public abstract class BaseUserAccountResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public UserAccount postAccountUserAccount(
+	public final UserAccount postAccountUserAccount(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("accountId")
@@ -1676,7 +1916,28 @@ public abstract class BaseUserAccountResourceImpl
 			UserAccount userAccount)
 		throws Exception {
 
-		return new UserAccount();
+		Permission[] permissions = userAccount.getPermissions();
+
+		UserAccount postUserAccount = doPostAccountUserAccount(
+			accountId, userAccount);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage = putUserAccountPermissionsPage(
+				postUserAccount.getId(), permissions);
+
+			postUserAccount.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postUserAccount;
 	}
 
 	/**
@@ -2208,6 +2469,10 @@ public abstract class BaseUserAccountResourceImpl
 		).build();
 	}
 
+	protected abstract UserAccount doPostUserAccount(
+			String captchaAnswer, String captchaToken, UserAccount userAccount)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -2236,7 +2501,7 @@ public abstract class BaseUserAccountResourceImpl
 	@jakarta.ws.rs.POST
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
-	public UserAccount postUserAccount(
+	public final UserAccount postUserAccount(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.ws.rs.QueryParam("captchaAnswer")
 			String captchaAnswer,
@@ -2246,7 +2511,28 @@ public abstract class BaseUserAccountResourceImpl
 			UserAccount userAccount)
 		throws Exception {
 
-		return new UserAccount();
+		Permission[] permissions = userAccount.getPermissions();
+
+		UserAccount postUserAccount = doPostUserAccount(
+			captchaAnswer, captchaToken, userAccount);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage = putUserAccountPermissionsPage(
+				postUserAccount.getId(), permissions);
+
+			postUserAccount.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return postUserAccount;
 	}
 
 	/**
@@ -2420,6 +2706,10 @@ public abstract class BaseUserAccountResourceImpl
 		).build();
 	}
 
+	protected abstract UserAccount doPutUserAccount(
+			Long userAccountId, UserAccount userAccount)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -2444,7 +2734,7 @@ public abstract class BaseUserAccountResourceImpl
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@jakarta.ws.rs.PUT
 	@Override
-	public UserAccount putUserAccount(
+	public final UserAccount putUserAccount(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("userAccountId")
@@ -2452,7 +2742,28 @@ public abstract class BaseUserAccountResourceImpl
 			UserAccount userAccount)
 		throws Exception {
 
-		return new UserAccount();
+		Permission[] permissions = userAccount.getPermissions();
+
+		UserAccount putUserAccount = doPutUserAccount(
+			userAccountId, userAccount);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage = putUserAccountPermissionsPage(
+				putUserAccount.getId(), permissions);
+
+			putUserAccount.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return putUserAccount;
 	}
 
 	/**
@@ -2499,6 +2810,10 @@ public abstract class BaseUserAccountResourceImpl
 		).build();
 	}
 
+	protected abstract UserAccount doPutUserAccountByExternalReferenceCode(
+			String externalReferenceCode, UserAccount userAccount)
+		throws Exception;
+
 	/**
 	 * Invoke this method with the command line:
 	 *
@@ -2522,7 +2837,7 @@ public abstract class BaseUserAccountResourceImpl
 	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
 	@jakarta.ws.rs.PUT
 	@Override
-	public UserAccount putUserAccountByExternalReferenceCode(
+	public final UserAccount putUserAccountByExternalReferenceCode(
 			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
 			@jakarta.validation.constraints.NotNull
 			@jakarta.ws.rs.PathParam("externalReferenceCode")
@@ -2530,7 +2845,121 @@ public abstract class BaseUserAccountResourceImpl
 			UserAccount userAccount)
 		throws Exception {
 
-		return new UserAccount();
+		Permission[] permissions = userAccount.getPermissions();
+
+		UserAccount putUserAccount = doPutUserAccountByExternalReferenceCode(
+			externalReferenceCode, userAccount);
+
+		if (permissions != null) {
+			Page<Permission> permissionsPage = putUserAccountPermissionsPage(
+				putUserAccount.getId(), permissions);
+
+			putUserAccount.setPermissions(
+				() -> NestedFieldsSupplier.supply(
+					"permissions",
+					nestedField -> {
+						Collection<Permission> collection =
+							permissionsPage.getItems();
+
+						return collection.toArray(
+							new Permission[collection.size()]);
+					}));
+		}
+
+		return putUserAccount;
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/{userAccountId}/permissions'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Overrides the userAccount permissions"
+	)
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "userAccountId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "UserAccount")}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/user-accounts/{userAccountId}/permissions")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public Page<Permission> putUserAccountPermissionsPage(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("userAccountId")
+			Long userAccountId,
+			Permission[] permissions)
+		throws Exception {
+
+		Long groupId = getPermissionCheckerGroupId(userAccountId);
+		Long resourceId = getPermissionCheckerResourceId(userAccountId);
+		String resourceName = getPermissionCheckerResourceName(userAccountId);
+
+		PermissionServiceUtil.checkPermission(
+			groupId, resourceName, resourceId);
+
+		ModelPermissions modelPermissions =
+			ModelPermissionsUtil.toModelPermissions(
+				contextCompany.getCompanyId(), permissions, resourceId,
+				resourceName, resourceActionLocalService,
+				resourcePermissionLocalService, roleLocalService);
+
+		Collection<String> roleNames = modelPermissions.getRoleNames();
+
+		for (ResourcePermission resourcePermission :
+				resourcePermissionLocalService.getResourcePermissions(
+					contextCompany.getCompanyId(), resourceName,
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId))) {
+
+			com.liferay.portal.kernel.model.Role role =
+				roleLocalService.fetchRole(resourcePermission.getRoleId());
+
+			if ((role == null) || roleNames.contains(role.getName())) {
+				continue;
+			}
+
+			for (ResourceAction resourceAction :
+					resourceActionLocalService.getResourceActions(
+						resourceName)) {
+
+				resourcePermissionLocalService.removeResourcePermission(
+					contextCompany.getCompanyId(), resourceName,
+					ResourceConstants.SCOPE_INDIVIDUAL,
+					String.valueOf(resourceId), role.getRoleId(),
+					resourceAction.getActionId());
+			}
+		}
+
+		resourcePermissionLocalService.updateResourcePermissions(
+			contextCompany.getCompanyId(), groupId, resourceName,
+			String.valueOf(resourceId), modelPermissions);
+
+		return toPermissionPage(
+			HashMapBuilder.put(
+				"get",
+				addAction(
+					ActionKeys.PERMISSIONS, resourceId,
+					"getUserAccountPermissionsPage", null, resourceName,
+					groupId)
+			).put(
+				"replace",
+				addAction(
+					ActionKeys.PERMISSIONS, resourceId,
+					"putUserAccountPermissionsPage", null, resourceName,
+					groupId)
+			).build(),
+			resourceId, resourceName, null);
 	}
 
 	@Override
@@ -2829,6 +3258,172 @@ public abstract class BaseUserAccountResourceImpl
 	@Override
 	public UserAccount getItem(Long id) throws Exception {
 		return getUserAccount(id);
+	}
+
+	protected String getPermissionCheckerActionsResourceName(Object id)
+		throws Exception {
+
+		return getPermissionCheckerResourceName(id);
+	}
+
+	protected Long getPermissionCheckerGroupId(Object id) throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected String getPermissionCheckerPortletName(Object id)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Long getPermissionCheckerResourceId(Object id) throws Exception {
+		return GetterUtil.getLong(id);
+	}
+
+	protected String getPermissionCheckerResourceName(Object id)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected Page<Permission> toPermissionPage(
+			Map<String, Map<String, String>> actions, long id,
+			String resourceName, String roleNames)
+		throws Exception {
+
+		List<ResourceAction> resourceActions =
+			resourceActionLocalService.getResourceActions(resourceName);
+
+		if (Validator.isNotNull(roleNames)) {
+			return Page.of(
+				actions,
+				_getPermissions(
+					contextCompany.getCompanyId(), resourceActions, id,
+					resourceName, StringUtil.split(roleNames)));
+		}
+
+		return Page.of(
+			actions,
+			_getPermissions(
+				contextCompany.getCompanyId(), resourceActions, id,
+				resourceName, null));
+	}
+
+	/**
+	 * @see com.liferay.portal.vulcan.permission.PermissionUtil#getPermissions(long, List, long, String, String[])
+	 */
+	private Collection<Permission> _getPermissions(
+			long companyId, List<ResourceAction> resourceActions,
+			long resourceId, String resourceName, String[] roleNames)
+		throws Exception {
+
+		Map<String, Permission> permissions = new HashMap<>();
+
+		int count = resourcePermissionLocalService.getResourcePermissionsCount(
+			companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(resourceId));
+
+		if (count == 0) {
+			ResourceLocalServiceUtil.addResources(
+				companyId, resourceId, 0, resourceName,
+				String.valueOf(resourceId), false, true, true);
+		}
+
+		List<String> actionIds = transform(
+			resourceActions, resourceAction -> resourceAction.getActionId());
+
+		Set<ResourcePermission> resourcePermissions = new HashSet<>();
+
+		resourcePermissions.addAll(
+			resourcePermissionLocalService.getResourcePermissions(
+				companyId, resourceName, ResourceConstants.SCOPE_COMPANY,
+				String.valueOf(companyId)));
+		resourcePermissions.addAll(
+			resourcePermissionLocalService.getResourcePermissions(
+				companyId, resourceName, ResourceConstants.SCOPE_GROUP,
+				String.valueOf(GroupThreadLocal.getGroupId())));
+		resourcePermissions.addAll(
+			resourcePermissionLocalService.getResourcePermissions(
+				companyId, resourceName, ResourceConstants.SCOPE_GROUP_TEMPLATE,
+				"0"));
+		resourcePermissions.addAll(
+			resourcePermissionLocalService.getResourcePermissions(
+				companyId, resourceName, ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(resourceId)));
+
+		List<Resource> resources = transform(
+			resourcePermissions,
+			resourcePermission -> ResourceLocalServiceUtil.getResource(
+				resourcePermission.getCompanyId(), resourcePermission.getName(),
+				resourcePermission.getScope(),
+				resourcePermission.getPrimKey()));
+
+		Set<com.liferay.portal.kernel.model.Role> roles = new HashSet<>();
+
+		if (roleNames != null) {
+			for (String roleName : roleNames) {
+				roles.add(roleLocalService.getRole(companyId, roleName));
+			}
+		}
+		else {
+			for (ResourcePermission resourcePermission : resourcePermissions) {
+				com.liferay.portal.kernel.model.Role role =
+					roleLocalService.getRole(resourcePermission.getRoleId());
+
+				roles.add(role);
+			}
+		}
+
+		for (com.liferay.portal.kernel.model.Role role : roles) {
+			Set<String> actionsIdsSet = new HashSet<>();
+
+			for (Resource resource : resources) {
+				actionsIdsSet.addAll(
+					resourcePermissionLocalService.
+						getAvailableResourcePermissionActionIds(
+							resource.getCompanyId(), resource.getName(),
+							ResourceConstants.SCOPE_COMPANY,
+							String.valueOf(resource.getCompanyId()),
+							role.getRoleId(), actionIds));
+				actionsIdsSet.addAll(
+					resourcePermissionLocalService.
+						getAvailableResourcePermissionActionIds(
+							resource.getCompanyId(), resource.getName(),
+							ResourceConstants.SCOPE_GROUP,
+							String.valueOf(GroupThreadLocal.getGroupId()),
+							role.getRoleId(), actionIds));
+				actionsIdsSet.addAll(
+					resourcePermissionLocalService.
+						getAvailableResourcePermissionActionIds(
+							resource.getCompanyId(), resource.getName(),
+							ResourceConstants.SCOPE_GROUP_TEMPLATE, "0",
+							role.getRoleId(), actionIds));
+				actionsIdsSet.addAll(
+					resourcePermissionLocalService.
+						getAvailableResourcePermissionActionIds(
+							resource.getCompanyId(), resource.getName(),
+							resource.getScope(), resource.getPrimKey(),
+							role.getRoleId(), actionIds));
+			}
+
+			if (actionsIdsSet.isEmpty()) {
+				continue;
+			}
+
+			Permission permission = new Permission() {
+				{
+					actionIds = actionsIdsSet.toArray(new String[0]);
+					roleName = role.getName();
+				}
+			};
+
+			permissions.put(role.getName(), permission);
+		}
+
+		return permissions.values();
 	}
 
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -18,6 +18,7 @@ import com.liferay.captcha.rest.resource.v1_0.CaptchaResource;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
+import com.liferay.exportimport.vulcan.batch.engine.ExportImportVulcanBatchEngineTaskItemDelegate;
 import com.liferay.headless.admin.user.dto.v1_0.Account;
 import com.liferay.headless.admin.user.dto.v1_0.AccountBrief;
 import com.liferay.headless.admin.user.dto.v1_0.EmailAddress;
@@ -120,6 +121,7 @@ import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.portlet.usersadmin.util.UsersAdminUtil;
 import com.liferay.user.associated.data.anonymizer.UADAnonymousUserProvider;
+import com.liferay.users.admin.constants.UsersAdminPortletKeys;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -155,7 +157,9 @@ import org.osgi.service.component.annotations.ServiceScope;
 	},
 	scope = ServiceScope.PROTOTYPE, service = UserAccountResource.class
 )
-public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
+public class UserAccountResourceImpl
+	extends BaseUserAccountResourceImpl
+	implements ExportImportVulcanBatchEngineTaskItemDelegate<UserAccount> {
 
 	@Override
 	public void
@@ -341,6 +345,33 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 				_portal.getClassNameId(User.class.getName()),
 				contextCompany.getCompanyId(), _expandoBridgeIndexer,
 				_expandoColumnLocalService, _expandoTableLocalService));
+	}
+
+	@Override
+	public ExportImportDescriptor getExportImportDescriptor() {
+		return new ExportImportDescriptor() {
+
+			@Override
+			public String getModelClassName() {
+				return User.class.getName();
+			}
+
+			@Override
+			public String getPortletId() {
+				return UsersAdminPortletKeys.USER_ADMIN;
+			}
+
+			@Override
+			public String getResourceClassName() {
+				return UserAccountResource.class.getName();
+			}
+
+			@Override
+			public Scope getScope() {
+				return Scope.SITE;
+			}
+
+		};
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -149,8 +149,11 @@ import org.osgi.service.component.annotations.ServiceScope;
  */
 @Component(
 	properties = "OSGI-INF/liferay/rest/v1_0/user-account.properties",
-	property = "nested.field.support=true", scope = ServiceScope.PROTOTYPE,
-	service = UserAccountResource.class
+	property = {
+		"export.import.vulcan.batch.engine.task.item.delegate=true",
+		"nested.field.support=true"
+	},
+	scope = ServiceScope.PROTOTYPE, service = UserAccountResource.class
 )
 public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -1041,131 +1041,22 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
+	protected UserAccount doPostSiteUserAccount(
+			Long siteId, String captchaAnswer, String captchaToken,
+			UserAccount userAccount)
+		throws Exception {
+
+		return _postUserAccount(
+			captchaAnswer, captchaToken, new long[] {siteId}, userAccount);
+	}
+
+	@Override
 	protected UserAccount doPostUserAccount(
 			String captchaAnswer, String captchaToken, UserAccount userAccount)
 		throws Exception {
 
-		User user = null;
-
-		boolean autoPassword = false;
-		String password = userAccount.getPassword();
-
-		if (Validator.isNull(password)) {
-			autoPassword = true;
-		}
-
-		ServiceContext serviceContext = ServiceContextFactory.getInstance(
-			contextHttpServletRequest);
-
-		serviceContext.setExpandoBridgeAttributes(
-			CustomFieldsUtil.toMap(
-				User.class.getName(), contextCompany.getCompanyId(),
-				userAccount.getCustomFields(),
-				contextAcceptLanguage.getPreferredLocale()));
-
-		if (Validator.isNull(serviceContext.getPathMain()) ||
-			Validator.isNull(serviceContext.getPortalURL())) {
-
-			Company company = _companyService.getCompanyById(
-				contextCompany.getCompanyId());
-
-			serviceContext.setPathMain(Portal.PATH_MAIN);
-			serviceContext.setPortalURL(company.getPortalURL(0));
-		}
-
-		if (contextUser.isGuestUser()) {
-			if (_captchaSettings.isCreateAccountCaptchaEnabled()) {
-				try {
-					_captchaResource.setContextCompany(contextCompany);
-					_captchaResource.setContextUser(contextUser);
-
-					_captchaResource.postCaptchaResponse(
-						new Captcha() {
-							{
-								setAnswer(() -> captchaAnswer);
-								setToken(() -> captchaToken);
-							}
-						});
-				}
-				catch (Exception exception) {
-					throw new CaptchaException(exception);
-				}
-			}
-
-			user = _userService.addUserWithWorkflow(
-				contextCompany.getCompanyId(), autoPassword, password, password,
-				false, userAccount.getAlternateName(),
-				userAccount.getEmailAddress(), _getLocale(userAccount),
-				userAccount.getGivenName(), userAccount.getAdditionalName(),
-				userAccount.getFamilyName(), _getPrefixId(null, userAccount),
-				_getSuffixId(null, userAccount),
-				_isMale(true, userAccount.getGender()),
-				_getBirthdayMonth(Calendar.JANUARY, userAccount),
-				_getBirthdayDay(1, userAccount),
-				_getBirthdayYear(1977, userAccount), userAccount.getJobTitle(),
-				new long[0], new long[0], new long[0], new long[0], true,
-				serviceContext);
-
-			PermissionThreadLocal.setPermissionChecker(
-				_permissionCheckerFactory.create(user));
-
-			UsersAdminUtil.updateAddresses(
-				Contact.class.getName(), user.getContactId(),
-				_getAddresses(null, userAccount),
-				ListTypeConstants.CONTACT_ADDRESS);
-			UsersAdminUtil.updateEmailAddresses(
-				Contact.class.getName(), user.getContactId(),
-				_getServiceBuilderEmailAddresses(null, userAccount));
-			UsersAdminUtil.updatePhones(
-				Contact.class.getName(), user.getContactId(),
-				_getServiceBuilderPhones(null, userAccount));
-			UsersAdminUtil.updateWebsites(
-				Contact.class.getName(), user.getContactId(),
-				_getWebsites(null, userAccount));
-		}
-		else {
-			user = _userService.addUserWithWorkflow(
-				contextCompany.getCompanyId(), autoPassword, password, password,
-				false, userAccount.getAlternateName(),
-				userAccount.getEmailAddress(), _getLocale(userAccount),
-				userAccount.getGivenName(), userAccount.getAdditionalName(),
-				userAccount.getFamilyName(), _getPrefixId(null, userAccount),
-				_getSuffixId(null, userAccount),
-				_isMale(true, userAccount.getGender()),
-				_getBirthdayMonth(Calendar.JANUARY, userAccount),
-				_getBirthdayDay(1, userAccount),
-				_getBirthdayYear(1977, userAccount), userAccount.getJobTitle(),
-				new long[0], new long[0], new long[0], new long[0],
-				_getAddresses(null, userAccount),
-				_getServiceBuilderEmailAddresses(null, userAccount),
-				_getServiceBuilderPhones(null, userAccount),
-				_getWebsites(null, userAccount), Collections.emptyList(), true,
-				serviceContext);
-		}
-
-		user = _userService.updateExternalReferenceCode(
-			user, userAccount.getExternalReferenceCode());
-		user = _userService.updatePortrait(
-			user.getUserId(), _getPortraitBytes(false, null, userAccount));
-
-		UserAccountContactInformation userAccountContactInformation =
-			userAccount.getUserAccountContactInformation();
-
-		if (userAccountContactInformation != null) {
-			Contact contact = user.getContact();
-
-			contact.setSmsSn(userAccountContactInformation.getSms());
-			contact.setFacebookSn(userAccountContactInformation.getFacebook());
-			contact.setJabberSn(userAccountContactInformation.getJabber());
-			contact.setSkypeSn(userAccountContactInformation.getSkype());
-			contact.setTwitterSn(userAccountContactInformation.getTwitter());
-
-			_contactLocalService.updateContact(contact);
-
-			user = _userService.getUserById(user.getUserId());
-		}
-
-		return _toUserAccount(user);
+		return _postUserAccount(
+			captchaAnswer, captchaToken, new long[0], userAccount);
 	}
 
 	@Override
@@ -1834,6 +1725,134 @@ public class UserAccountResourceImpl
 		}
 
 		return false;
+	}
+
+	private UserAccount _postUserAccount(
+			String captchaAnswer, String captchaToken, long[] groupIds,
+			UserAccount userAccount)
+		throws Exception {
+
+		User user = null;
+
+		boolean autoPassword = false;
+		String password = userAccount.getPassword();
+
+		if (Validator.isNull(password)) {
+			autoPassword = true;
+		}
+
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			contextHttpServletRequest);
+
+		serviceContext.setExpandoBridgeAttributes(
+			CustomFieldsUtil.toMap(
+				User.class.getName(), contextCompany.getCompanyId(),
+				userAccount.getCustomFields(),
+				contextAcceptLanguage.getPreferredLocale()));
+
+		if (Validator.isNull(serviceContext.getPathMain()) ||
+			Validator.isNull(serviceContext.getPortalURL())) {
+
+			Company company = _companyService.getCompanyById(
+				contextCompany.getCompanyId());
+
+			serviceContext.setPathMain(Portal.PATH_MAIN);
+			serviceContext.setPortalURL(company.getPortalURL(0));
+		}
+
+		if (contextUser.isGuestUser()) {
+			if (_captchaSettings.isCreateAccountCaptchaEnabled()) {
+				try {
+					_captchaResource.setContextCompany(contextCompany);
+					_captchaResource.setContextUser(contextUser);
+
+					_captchaResource.postCaptchaResponse(
+						new Captcha() {
+							{
+								setAnswer(() -> captchaAnswer);
+								setToken(() -> captchaToken);
+							}
+						});
+				}
+				catch (Exception exception) {
+					throw new CaptchaException(exception);
+				}
+			}
+
+			user = _userService.addUserWithWorkflow(
+				contextCompany.getCompanyId(), autoPassword, password, password,
+				false, userAccount.getAlternateName(),
+				userAccount.getEmailAddress(), _getLocale(userAccount),
+				userAccount.getGivenName(), userAccount.getAdditionalName(),
+				userAccount.getFamilyName(), _getPrefixId(null, userAccount),
+				_getSuffixId(null, userAccount),
+				_isMale(true, userAccount.getGender()),
+				_getBirthdayMonth(Calendar.JANUARY, userAccount),
+				_getBirthdayDay(1, userAccount),
+				_getBirthdayYear(1977, userAccount), userAccount.getJobTitle(),
+				groupIds, new long[0], new long[0], new long[0], true,
+				serviceContext);
+
+			PermissionThreadLocal.setPermissionChecker(
+				_permissionCheckerFactory.create(user));
+
+			UsersAdminUtil.updateAddresses(
+				Contact.class.getName(), user.getContactId(),
+				_getAddresses(null, userAccount),
+				ListTypeConstants.CONTACT_ADDRESS);
+			UsersAdminUtil.updateEmailAddresses(
+				Contact.class.getName(), user.getContactId(),
+				_getServiceBuilderEmailAddresses(null, userAccount));
+			UsersAdminUtil.updatePhones(
+				Contact.class.getName(), user.getContactId(),
+				_getServiceBuilderPhones(null, userAccount));
+			UsersAdminUtil.updateWebsites(
+				Contact.class.getName(), user.getContactId(),
+				_getWebsites(null, userAccount));
+		}
+		else {
+			user = _userService.addUserWithWorkflow(
+				contextCompany.getCompanyId(), autoPassword, password, password,
+				false, userAccount.getAlternateName(),
+				userAccount.getEmailAddress(), _getLocale(userAccount),
+				userAccount.getGivenName(), userAccount.getAdditionalName(),
+				userAccount.getFamilyName(), _getPrefixId(null, userAccount),
+				_getSuffixId(null, userAccount),
+				_isMale(true, userAccount.getGender()),
+				_getBirthdayMonth(Calendar.JANUARY, userAccount),
+				_getBirthdayDay(1, userAccount),
+				_getBirthdayYear(1977, userAccount), userAccount.getJobTitle(),
+				groupIds, new long[0], new long[0], new long[0],
+				_getAddresses(null, userAccount),
+				_getServiceBuilderEmailAddresses(null, userAccount),
+				_getServiceBuilderPhones(null, userAccount),
+				_getWebsites(null, userAccount), Collections.emptyList(), true,
+				serviceContext);
+		}
+
+		user = _userService.updateExternalReferenceCode(
+			user, userAccount.getExternalReferenceCode());
+		user = _userService.updatePortrait(
+			user.getUserId(), _getPortraitBytes(false, null, userAccount));
+
+		UserAccountContactInformation userAccountContactInformation =
+			userAccount.getUserAccountContactInformation();
+
+		if (userAccountContactInformation != null) {
+			Contact contact = user.getContact();
+
+			contact.setSmsSn(userAccountContactInformation.getSms());
+			contact.setFacebookSn(userAccountContactInformation.getFacebook());
+			contact.setJabberSn(userAccountContactInformation.getJabber());
+			contact.setSkypeSn(userAccountContactInformation.getSkype());
+			contact.setTwitterSn(userAccountContactInformation.getTwitter());
+
+			_contactLocalService.updateContact(contact);
+
+			user = _userService.getUserById(user.getUserId());
+		}
+
+		return _toUserAccount(user);
 	}
 
 	private UserAccount _toUserAccount(

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -1277,6 +1277,23 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
+	protected Long getPermissionCheckerGroupId(Object id) throws Exception {
+		User user = _userService.getUserById((Long)id);
+
+		return user.getGroupId();
+	}
+
+	@Override
+	protected String getPermissionCheckerPortletName(Object id) {
+		return "com.liferay.portal.kernel.model.User";
+	}
+
+	@Override
+	protected String getPermissionCheckerResourceName(Object id) {
+		return User.class.getName();
+	}
+
+	@Override
 	protected void preparePatch(
 		UserAccount userAccount, UserAccount existingUserAccount) {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -286,58 +286,6 @@ public class UserAccountResourceImpl
 			search, filter, pagination, sorts);
 	}
 
-	@NestedField(parentClass = Account.class, value = "accountUserAccounts")
-	@Override
-	public Page<UserAccount> getAccountUserAccountsPage(
-			@NestedFieldId(value = "id") Long accountId, String search,
-			Filter filter, Pagination pagination, Sort[] sorts)
-		throws Exception {
-
-		Map<String, Map<String, String>> actions = _getModelActions(
-			Collections.singletonMap(
-				ActionKeys.MANAGE_USERS,
-				new String[] {
-					"deleteAccountUserAccountByEmailAddress",
-					"deleteAccountUserAccountByExternalReferenceCodeBy" +
-						"EmailAddress",
-					"deleteAccountUserAccountsByEmailAddress",
-					"deleteAccountUserAccountsByExternalReferenceCodeBy" +
-						"EmailAddress",
-					"getAccountUserAccountsByExternalReferenceCodePage",
-					"getAccountUserAccountsPage", "postAccountUserAccount",
-					"postAccountUserAccountBatch",
-					"postAccountUserAccountByEmailAddress",
-					"postAccountUserAccountByExternalReferenceCode",
-					"postAccountUserAccountByExternalReferenceCodeBy" +
-						"EmailAddress",
-					"postAccountUserAccountsByEmailAddress",
-					"postAccountUserAccountsByExternalReferenceCodeBy" +
-						"EmailAddress"
-				}),
-			accountId, _accountEntryModelResourcePermission);
-
-		return SearchUtil.search(
-			actions,
-			booleanQuery -> {
-				BooleanFilter booleanFilter =
-					booleanQuery.getPreBooleanFilter();
-
-				booleanFilter.add(
-					new TermFilter(
-						"accountEntryIds", String.valueOf(accountId)),
-					BooleanClauseOccur.MUST);
-			},
-			filter, User.class.getName(), search, pagination,
-			queryConfig -> queryConfig.setSelectedFieldNames(
-				Field.ENTRY_CLASS_PK),
-			searchContext -> searchContext.setCompanyId(
-				contextCompany.getCompanyId()),
-			sorts,
-			document -> _toUserAccount(
-				actions,
-				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))));
-	}
-
 	@Override
 	public EntityModel getEntityModel(MultivaluedMap multivaluedMap) {
 		return new UserAccountEntityModel(
@@ -399,40 +347,6 @@ public class UserAccountResourceImpl
 			pagination, sorts);
 	}
 
-	@NestedField(
-		parentClass = com.liferay.headless.admin.user.dto.v1_0.Organization.class,
-		value = "userAccounts"
-	)
-	@Override
-	public Page<UserAccount> getOrganizationUserAccountsPage(
-			@NestedFieldId(value = "id") String organizationId, String search,
-			Filter filter, Pagination pagination, Sort[] sorts)
-		throws Exception {
-
-		return _getUserAccountsPage(
-			_getModelActions(
-				Collections.singletonMap(
-					ActionKeys.MANAGE_USERS,
-					new String[] {"getOrganizationUserAccountsPage"}),
-				DTOConverterUtil.getModelPrimaryKey(
-					_organizationOrganizationDTOConverter, organizationId),
-				_organizationModelResourcePermission),
-			booleanQuery -> {
-				BooleanFilter booleanFilter =
-					booleanQuery.getPreBooleanFilter();
-
-				booleanFilter.add(
-					new TermFilter(
-						"organizationIds",
-						String.valueOf(
-							DTOConverterUtil.getModelPrimaryKey(
-								_organizationOrganizationDTOConverter,
-								organizationId))),
-					BooleanClauseOccur.MUST);
-			},
-			filter, search, pagination, sorts, null);
-	}
-
 	@Override
 	public Boolean getSiteAccountUserAccountSelected(
 			Long siteId, Long accountId, Long userAccountId)
@@ -476,50 +390,12 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public Page<UserAccount> getSiteUserAccountsPage(
-			Long siteId, String search, Filter filter, Pagination pagination,
-			Sort[] sorts)
-		throws Exception {
-
-		return _getUserAccountsPage(
-			Collections.singletonMap(
-				_formatActionMapKey("getSiteUserAccountsPage"),
-				addAction(
-					_formatActionMapKey("getSiteUserAccountsPage"),
-					"getSiteUserAccountsPage", User.class.getName(), siteId)),
-			booleanQuery -> {
-				BooleanFilter booleanFilter =
-					booleanQuery.getPreBooleanFilter();
-
-				booleanFilter.add(
-					new TermFilter("groupId", String.valueOf(siteId)),
-					BooleanClauseOccur.MUST);
-			},
-			filter, search, pagination, sorts, null);
-	}
-
-	@Override
-	public UserAccount getUserAccount(Long userAccountId) throws Exception {
-		return _toUserAccount(_userService.getUserById(userAccountId));
-	}
-
-	@Override
 	public UserAccount getUserAccountByEmailAddress(String emailAddress)
 		throws Exception {
 
 		return _toUserAccount(
 			_userService.getUserByEmailAddress(
 				contextCompany.getCompanyId(), emailAddress));
-	}
-
-	@Override
-	public UserAccount getUserAccountByExternalReferenceCode(
-			String externalReferenceCode)
-		throws Exception {
-
-		return _toUserAccount(
-			_userService.getUserByExternalReferenceCode(
-				externalReferenceCode, contextCompany.getCompanyId()));
 	}
 
 	@Override
@@ -576,36 +452,6 @@ public class UserAccountResourceImpl
 					BooleanClauseOccur.MUST_NOT);
 			},
 			filter, search, pagination, sorts, statusInteger);
-	}
-
-	@Override
-	public Page<UserAccount> getUserAccountsPage(
-			String search, Filter filter, Pagination pagination, Sort[] sorts)
-		throws Exception {
-
-		return _getUserAccountsPage(
-			HashMapBuilder.<String, Map<String, String>>putAll(
-				_getCompanyScopeActions(
-					ActionKeys.VIEW, new String[] {"getUserAccountsPage"},
-					User.class.getName())
-			).putAll(
-				_getCompanyScopeActions(
-					ActionKeys.ADD_USER,
-					new String[] {
-						"postUserAccount",
-						"putUserAccountByExternalReferenceCode"
-					},
-					PortletKeys.PORTAL)
-			).build(),
-			booleanQuery -> {
-				BooleanFilter booleanFilter =
-					booleanQuery.getPreBooleanFilter();
-
-				booleanFilter.add(
-					new TermFilter("userName", StringPool.BLANK),
-					BooleanClauseOccur.MUST_NOT);
-			},
-			filter, search, pagination, sorts, null);
 	}
 
 	@Override
@@ -863,75 +709,6 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public UserAccount postAccountUserAccount(
-			Long accountId, UserAccount userAccount)
-		throws Exception {
-
-		AccountEntryUserRel accountEntryUserRel =
-			_accountEntryUserRelService.addAccountEntryUserRel(
-				accountId, contextUser.getUserId(),
-				userAccount.getAlternateName(), userAccount.getEmailAddress(),
-				_getLocale(userAccount), userAccount.getGivenName(),
-				userAccount.getAdditionalName(), userAccount.getFamilyName(),
-				_getPrefixId(null, userAccount),
-				_getSuffixId(null, userAccount), userAccount.getJobTitle(),
-				ServiceContextFactory.getInstance(contextHttpServletRequest));
-
-		User user = accountEntryUserRel.getUser();
-
-		Contact contact = user.getContact();
-
-		String sms = null;
-		String facebook = null;
-		String jabber = null;
-		String skype = null;
-		String twitter = null;
-
-		UserAccountContactInformation userAccountContactInformation =
-			userAccount.getUserAccountContactInformation();
-
-		if (userAccountContactInformation != null) {
-			sms = userAccountContactInformation.getSms();
-			facebook = userAccountContactInformation.getFacebook();
-			jabber = userAccountContactInformation.getJabber();
-			skype = userAccountContactInformation.getSkype();
-			twitter = userAccountContactInformation.getTwitter();
-		}
-
-		user = _userLocalService.updateUser(
-			user.getUserId(), null, null, null, false,
-			user.getReminderQueryQuestion(), user.getReminderQueryAnswer(),
-			user.getScreenName(), user.getEmailAddress(),
-			_hasPortrait(null, userAccount),
-			_getPortraitBytes(false, user, userAccount), user.getLanguageId(),
-			user.getTimeZoneId(), user.getGreeting(), user.getComments(),
-			user.getFirstName(), user.getMiddleName(), user.getLastName(),
-			contact.getPrefixListTypeId(), contact.getSuffixListTypeId(),
-			user.isMale(), _getBirthdayMonth(Calendar.JANUARY, userAccount),
-			_getBirthdayDay(1, userAccount),
-			_getBirthdayYear(1977, userAccount), sms, facebook, jabber, skype,
-			twitter, user.getJobTitle(), user.getGroupIds(),
-			user.getOrganizationIds(), user.getRoleIds(), null,
-			user.getUserGroupIds(), _createServiceContext(userAccount));
-
-		UsersAdminUtil.updateAddresses(
-			Contact.class.getName(), user.getContactId(),
-			_getAddresses(null, userAccount),
-			ListTypeConstants.CONTACT_ADDRESS);
-		UsersAdminUtil.updateEmailAddresses(
-			Contact.class.getName(), user.getContactId(),
-			_getServiceBuilderEmailAddresses(null, userAccount));
-		UsersAdminUtil.updatePhones(
-			Contact.class.getName(), user.getContactId(),
-			_getServiceBuilderPhones(null, userAccount));
-		UsersAdminUtil.updateWebsites(
-			Contact.class.getName(), user.getContactId(),
-			_getWebsites(null, userAccount));
-
-		return _toUserAccount(user);
-	}
-
-	@Override
 	public UserAccount postAccountUserAccountByEmailAddress(
 			Long accountId, String emailAddress)
 		throws Exception {
@@ -1026,7 +803,245 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public UserAccount postUserAccount(
+	public Response postUserAccountImage(
+			Long userAccountId, MultipartBody multipartBody)
+		throws Exception {
+
+		_userService.updatePortrait(
+			userAccountId, multipartBody.getBinaryFileAsBytes("image"));
+
+		Response.ResponseBuilder responseBuilder = Response.noContent();
+
+		return responseBuilder.build();
+	}
+
+	@NestedField(parentClass = Account.class, value = "accountUserAccounts")
+	@Override
+	protected Page<UserAccount> doGetAccountUserAccountsPage(
+			@NestedFieldId(value = "id") Long accountId, String search,
+			Filter filter, Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		Map<String, Map<String, String>> actions = _getModelActions(
+			Collections.singletonMap(
+				ActionKeys.MANAGE_USERS,
+				new String[] {
+					"deleteAccountUserAccountByEmailAddress",
+					"deleteAccountUserAccountByExternalReferenceCodeBy" +
+						"EmailAddress",
+					"deleteAccountUserAccountsByEmailAddress",
+					"deleteAccountUserAccountsByExternalReferenceCodeBy" +
+						"EmailAddress",
+					"getAccountUserAccountsByExternalReferenceCodePage",
+					"getAccountUserAccountsPage", "postAccountUserAccount",
+					"postAccountUserAccountBatch",
+					"postAccountUserAccountByEmailAddress",
+					"postAccountUserAccountByExternalReferenceCode",
+					"postAccountUserAccountByExternalReferenceCodeBy" +
+						"EmailAddress",
+					"postAccountUserAccountsByEmailAddress",
+					"postAccountUserAccountsByExternalReferenceCodeBy" +
+						"EmailAddress"
+				}),
+			accountId, _accountEntryModelResourcePermission);
+
+		return SearchUtil.search(
+			actions,
+			booleanQuery -> {
+				BooleanFilter booleanFilter =
+					booleanQuery.getPreBooleanFilter();
+
+				booleanFilter.add(
+					new TermFilter(
+						"accountEntryIds", String.valueOf(accountId)),
+					BooleanClauseOccur.MUST);
+			},
+			filter, User.class.getName(), search, pagination,
+			queryConfig -> queryConfig.setSelectedFieldNames(
+				Field.ENTRY_CLASS_PK),
+			searchContext -> searchContext.setCompanyId(
+				contextCompany.getCompanyId()),
+			sorts,
+			document -> _toUserAccount(
+				actions,
+				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK))));
+	}
+
+	@NestedField(
+		parentClass = com.liferay.headless.admin.user.dto.v1_0.Organization.class,
+		value = "userAccounts"
+	)
+	@Override
+	protected Page<UserAccount> doGetOrganizationUserAccountsPage(
+			@NestedFieldId(value = "id") String organizationId, String search,
+			Filter filter, Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		return _getUserAccountsPage(
+			_getModelActions(
+				Collections.singletonMap(
+					ActionKeys.MANAGE_USERS,
+					new String[] {"getOrganizationUserAccountsPage"}),
+				DTOConverterUtil.getModelPrimaryKey(
+					_organizationOrganizationDTOConverter, organizationId),
+				_organizationModelResourcePermission),
+			booleanQuery -> {
+				BooleanFilter booleanFilter =
+					booleanQuery.getPreBooleanFilter();
+
+				booleanFilter.add(
+					new TermFilter(
+						"organizationIds",
+						String.valueOf(
+							DTOConverterUtil.getModelPrimaryKey(
+								_organizationOrganizationDTOConverter,
+								organizationId))),
+					BooleanClauseOccur.MUST);
+			},
+			filter, search, pagination, sorts, null);
+	}
+
+	@Override
+	protected Page<UserAccount> doGetSiteUserAccountsPage(
+			Long siteId, String search, Filter filter, Pagination pagination,
+			Sort[] sorts)
+		throws Exception {
+
+		return _getUserAccountsPage(
+			Collections.singletonMap(
+				_formatActionMapKey("getSiteUserAccountsPage"),
+				addAction(
+					_formatActionMapKey("getSiteUserAccountsPage"),
+					"getSiteUserAccountsPage", User.class.getName(), siteId)),
+			booleanQuery -> {
+				BooleanFilter booleanFilter =
+					booleanQuery.getPreBooleanFilter();
+
+				booleanFilter.add(
+					new TermFilter("groupId", String.valueOf(siteId)),
+					BooleanClauseOccur.MUST);
+			},
+			filter, search, pagination, sorts, null);
+	}
+
+	@Override
+	protected UserAccount doGetUserAccount(Long userAccountId)
+		throws Exception {
+
+		return _toUserAccount(_userService.getUserById(userAccountId));
+	}
+
+	@Override
+	protected UserAccount doGetUserAccountByExternalReferenceCode(
+			String externalReferenceCode)
+		throws Exception {
+
+		return _toUserAccount(
+			_userService.getUserByExternalReferenceCode(
+				externalReferenceCode, contextCompany.getCompanyId()));
+	}
+
+	@Override
+	protected Page<UserAccount> doGetUserAccountsPage(
+			String search, Filter filter, Pagination pagination, Sort[] sorts)
+		throws Exception {
+
+		return _getUserAccountsPage(
+			HashMapBuilder.<String, Map<String, String>>putAll(
+				_getCompanyScopeActions(
+					ActionKeys.VIEW, new String[] {"getUserAccountsPage"},
+					User.class.getName())
+			).putAll(
+				_getCompanyScopeActions(
+					ActionKeys.ADD_USER,
+					new String[] {
+						"postUserAccount",
+						"putUserAccountByExternalReferenceCode"
+					},
+					PortletKeys.PORTAL)
+			).build(),
+			booleanQuery -> {
+				BooleanFilter booleanFilter =
+					booleanQuery.getPreBooleanFilter();
+
+				booleanFilter.add(
+					new TermFilter("userName", StringPool.BLANK),
+					BooleanClauseOccur.MUST_NOT);
+			},
+			filter, search, pagination, sorts, null);
+	}
+
+	@Override
+	protected UserAccount doPostAccountUserAccount(
+			Long accountId, UserAccount userAccount)
+		throws Exception {
+
+		AccountEntryUserRel accountEntryUserRel =
+			_accountEntryUserRelService.addAccountEntryUserRel(
+				accountId, contextUser.getUserId(),
+				userAccount.getAlternateName(), userAccount.getEmailAddress(),
+				_getLocale(userAccount), userAccount.getGivenName(),
+				userAccount.getAdditionalName(), userAccount.getFamilyName(),
+				_getPrefixId(null, userAccount),
+				_getSuffixId(null, userAccount), userAccount.getJobTitle(),
+				ServiceContextFactory.getInstance(contextHttpServletRequest));
+
+		User user = accountEntryUserRel.getUser();
+
+		Contact contact = user.getContact();
+
+		String sms = null;
+		String facebook = null;
+		String jabber = null;
+		String skype = null;
+		String twitter = null;
+
+		UserAccountContactInformation userAccountContactInformation =
+			userAccount.getUserAccountContactInformation();
+
+		if (userAccountContactInformation != null) {
+			sms = userAccountContactInformation.getSms();
+			facebook = userAccountContactInformation.getFacebook();
+			jabber = userAccountContactInformation.getJabber();
+			skype = userAccountContactInformation.getSkype();
+			twitter = userAccountContactInformation.getTwitter();
+		}
+
+		user = _userLocalService.updateUser(
+			user.getUserId(), null, null, null, false,
+			user.getReminderQueryQuestion(), user.getReminderQueryAnswer(),
+			user.getScreenName(), user.getEmailAddress(),
+			_hasPortrait(null, userAccount),
+			_getPortraitBytes(false, user, userAccount), user.getLanguageId(),
+			user.getTimeZoneId(), user.getGreeting(), user.getComments(),
+			user.getFirstName(), user.getMiddleName(), user.getLastName(),
+			contact.getPrefixListTypeId(), contact.getSuffixListTypeId(),
+			user.isMale(), _getBirthdayMonth(Calendar.JANUARY, userAccount),
+			_getBirthdayDay(1, userAccount),
+			_getBirthdayYear(1977, userAccount), sms, facebook, jabber, skype,
+			twitter, user.getJobTitle(), user.getGroupIds(),
+			user.getOrganizationIds(), user.getRoleIds(), null,
+			user.getUserGroupIds(), _createServiceContext(userAccount));
+
+		UsersAdminUtil.updateAddresses(
+			Contact.class.getName(), user.getContactId(),
+			_getAddresses(null, userAccount),
+			ListTypeConstants.CONTACT_ADDRESS);
+		UsersAdminUtil.updateEmailAddresses(
+			Contact.class.getName(), user.getContactId(),
+			_getServiceBuilderEmailAddresses(null, userAccount));
+		UsersAdminUtil.updatePhones(
+			Contact.class.getName(), user.getContactId(),
+			_getServiceBuilderPhones(null, userAccount));
+		UsersAdminUtil.updateWebsites(
+			Contact.class.getName(), user.getContactId(),
+			_getWebsites(null, userAccount));
+
+		return _toUserAccount(user);
+	}
+
+	@Override
+	protected UserAccount doPostUserAccount(
 			String captchaAnswer, String captchaToken, UserAccount userAccount)
 		throws Exception {
 
@@ -1154,20 +1169,7 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public Response postUserAccountImage(
-			Long userAccountId, MultipartBody multipartBody)
-		throws Exception {
-
-		_userService.updatePortrait(
-			userAccountId, multipartBody.getBinaryFileAsBytes("image"));
-
-		Response.ResponseBuilder responseBuilder = Response.noContent();
-
-		return responseBuilder.build();
-	}
-
-	@Override
-	public UserAccount putUserAccount(
+	protected UserAccount doPutUserAccount(
 			Long userAccountId, UserAccount userAccount)
 		throws Exception {
 
@@ -1260,7 +1262,7 @@ public class UserAccountResourceImpl
 	}
 
 	@Override
-	public UserAccount putUserAccountByExternalReferenceCode(
+	protected UserAccount doPutUserAccountByExternalReferenceCode(
 			String externalReferenceCode, UserAccount userAccount)
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -13,10 +13,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 
+import com.liferay.headless.admin.user.client.dto.v1_0.Role;
 import com.liferay.headless.admin.user.client.dto.v1_0.UserAccount;
 import com.liferay.headless.admin.user.client.http.HttpInvoker;
 import com.liferay.headless.admin.user.client.pagination.Page;
 import com.liferay.headless.admin.user.client.pagination.Pagination;
+import com.liferay.headless.admin.user.client.permission.Permission;
 import com.liferay.headless.admin.user.client.resource.v1_0.UserAccountResource;
 import com.liferay.headless.admin.user.client.serdes.v1_0.UserAccountSerDes;
 import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
@@ -33,6 +35,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -42,6 +45,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateUtil;
@@ -153,6 +157,18 @@ public abstract class BaseUserAccountResourceTestCase {
 			testCompany.getVirtualHostname(), 8080, "http"
 		).locale(
 			LocaleUtil.getDefault()
+		).build();
+
+		permissionsUserAccountResource = UserAccountResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(), 8080, "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).parameter(
+			"nestedFields", "permissions"
 		).build();
 	}
 
@@ -2183,6 +2199,17 @@ public abstract class BaseUserAccountResourceTestCase {
 		assertValid(
 			page, testGetAccountUserAccountsPage_getExpectedActions(accountId));
 
+		for (UserAccount userAccount : page.getItems()) {
+			Assert.assertNull(userAccount.getPermissions());
+		}
+
+		page = permissionsUserAccountResource.getAccountUserAccountsPage(
+			accountId, null, null, Pagination.of(1, 10), null);
+
+		for (UserAccount userAccount : page.getItems()) {
+			Assert.assertNotNull(userAccount.getPermissions());
+		}
+
 		userAccountResource.deleteUserAccount(userAccount1.getId());
 
 		userAccountResource.deleteUserAccount(userAccount2.getId());
@@ -3187,6 +3214,17 @@ public abstract class BaseUserAccountResourceTestCase {
 			testGetOrganizationUserAccountsPage_getExpectedActions(
 				organizationId));
 
+		for (UserAccount userAccount : page.getItems()) {
+			Assert.assertNull(userAccount.getPermissions());
+		}
+
+		page = permissionsUserAccountResource.getOrganizationUserAccountsPage(
+			organizationId, null, null, Pagination.of(1, 10), null);
+
+		for (UserAccount userAccount : page.getItems()) {
+			Assert.assertNotNull(userAccount.getPermissions());
+		}
+
 		userAccountResource.deleteUserAccount(userAccount1.getId());
 
 		userAccountResource.deleteUserAccount(userAccount2.getId());
@@ -3629,6 +3667,17 @@ public abstract class BaseUserAccountResourceTestCase {
 		assertValid(
 			page, testGetSiteUserAccountsPage_getExpectedActions(siteId));
 
+		for (UserAccount userAccount : page.getItems()) {
+			Assert.assertNull(userAccount.getPermissions());
+		}
+
+		page = permissionsUserAccountResource.getSiteUserAccountsPage(
+			siteId, null, null, Pagination.of(1, 10), null);
+
+		for (UserAccount userAccount : page.getItems()) {
+			Assert.assertNotNull(userAccount.getPermissions());
+		}
+
 		userAccountResource.deleteUserAccount(userAccount1.getId());
 
 		userAccountResource.deleteUserAccount(userAccount2.getId());
@@ -3993,6 +4042,13 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		assertEquals(postUserAccount, getUserAccount);
 		assertValid(getUserAccount);
+
+		Assert.assertNull(getUserAccount.getPermissions());
+
+		getUserAccount = permissionsUserAccountResource.getUserAccount(
+			postUserAccount.getId());
+
+		Assert.assertNotNull(getUserAccount.getPermissions());
 	}
 
 	@Test
@@ -4422,6 +4478,15 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		assertEquals(postUserAccount, getUserAccount);
 		assertValid(getUserAccount);
+
+		Assert.assertNull(getUserAccount.getPermissions());
+
+		getUserAccount =
+			permissionsUserAccountResource.
+				getUserAccountByExternalReferenceCode(
+					postUserAccount.getExternalReferenceCode());
+
+		Assert.assertNotNull(getUserAccount.getPermissions());
 	}
 
 	protected UserAccount
@@ -4540,6 +4605,56 @@ public abstract class BaseUserAccountResourceTestCase {
 
 	protected UserAccount
 			testGraphQLGetUserAccountByExternalReferenceCode_addUserAccount()
+		throws Exception {
+
+		return testGraphQLUserAccount_addUserAccount();
+	}
+
+	@Test
+	public void testGetUserAccountPermissionsPage() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		UserAccount postUserAccount =
+			testGetUserAccountPermissionsPage_addUserAccount();
+
+		Page<Permission> page =
+			userAccountResource.getUserAccountPermissionsPage(
+				postUserAccount.getId(), RoleConstants.GUEST);
+
+		Assert.assertNotNull(page);
+	}
+
+	protected UserAccount testGetUserAccountPermissionsPage_addUserAccount()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLGetUserAccountPermissionsPage() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		UserAccount postUserAccount =
+			testGraphQLGetUserAccountPermissionsPage_addUserAccount();
+
+		GraphQLField graphQLField = new GraphQLField(
+			"userAccountPermissions",
+			new HashMap<String, Object>() {
+				{
+					put("userAccountId", postUserAccount.getId());
+				}
+			},
+			new GraphQLField("page"), new GraphQLField("totalCount"));
+
+		JSONObject userAccountPermissionsJSONObject =
+			JSONUtil.getValueAsJSONObject(
+				invokeGraphQLQuery(graphQLField), "JSONObject/data",
+				"JSONObject/userAccountPermissions");
+
+		Assert.assertNotNull(userAccountPermissionsJSONObject);
+	}
+
+	protected UserAccount
+			testGraphQLGetUserAccountPermissionsPage_addUserAccount()
 		throws Exception {
 
 		return testGraphQLUserAccount_addUserAccount();
@@ -5077,6 +5192,17 @@ public abstract class BaseUserAccountResourceTestCase {
 		assertContains(userAccount1, (List<UserAccount>)page.getItems());
 		assertContains(userAccount2, (List<UserAccount>)page.getItems());
 		assertValid(page, testGetUserAccountsPage_getExpectedActions());
+
+		for (UserAccount userAccount : page.getItems()) {
+			Assert.assertNull(userAccount.getPermissions());
+		}
+
+		page = permissionsUserAccountResource.getUserAccountsPage(
+			null, null, Pagination.of(1, 10), null);
+
+		for (UserAccount userAccount : page.getItems()) {
+			Assert.assertNotNull(userAccount.getPermissions());
+		}
 
 		userAccountResource.deleteUserAccount(userAccount1.getId());
 
@@ -6518,6 +6644,24 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		assertEquals(randomUserAccount, postUserAccount);
 		assertValid(postUserAccount);
+
+		UserAccount randomPermissionsUserAccount1 =
+			randomPermissionsUserAccount();
+
+		UserAccount postPermissionsUserAccount1 =
+			testPostAccountUserAccount_addUserAccount(
+				randomPermissionsUserAccount1);
+
+		Assert.assertNull(postPermissionsUserAccount1.getPermissions());
+
+		UserAccount randomPermissionsUserAccount2 =
+			randomPermissionsUserAccount();
+
+		UserAccount postPermissionsUserAccount2 =
+			testPostAccountUserAccount_addPermissionsUserAccount(
+				randomPermissionsUserAccount2);
+
+		Assert.assertNotNull(postPermissionsUserAccount2.getPermissions());
 	}
 
 	protected UserAccount testPostAccountUserAccount_addUserAccount(
@@ -6525,6 +6669,14 @@ public abstract class BaseUserAccountResourceTestCase {
 		throws Exception {
 
 		return userAccountResource.postAccountUserAccount(
+			testGetAccountUserAccountsPage_getAccountId(), userAccount);
+	}
+
+	protected UserAccount testPostAccountUserAccount_addPermissionsUserAccount(
+			UserAccount userAccount)
+		throws Exception {
+
+		return permissionsUserAccountResource.postAccountUserAccount(
 			testGetAccountUserAccountsPage_getAccountId(), userAccount);
 	}
 
@@ -6679,9 +6831,34 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		assertEquals(randomUserAccount, postUserAccount);
 		assertValid(postUserAccount);
+
+		UserAccount randomPermissionsUserAccount1 =
+			randomPermissionsUserAccount();
+
+		UserAccount postPermissionsUserAccount1 =
+			testPostUserAccount_addUserAccount(randomPermissionsUserAccount1);
+
+		Assert.assertNull(postPermissionsUserAccount1.getPermissions());
+
+		UserAccount randomPermissionsUserAccount2 =
+			randomPermissionsUserAccount();
+
+		UserAccount postPermissionsUserAccount2 =
+			testPostUserAccount_addPermissionsUserAccount(
+				randomPermissionsUserAccount2);
+
+		Assert.assertNotNull(postPermissionsUserAccount2.getPermissions());
 	}
 
 	protected UserAccount testPostUserAccount_addUserAccount(
+			UserAccount userAccount)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected UserAccount testPostUserAccount_addPermissionsUserAccount(
 			UserAccount userAccount)
 		throws Exception {
 
@@ -6716,11 +6893,29 @@ public abstract class BaseUserAccountResourceTestCase {
 		assertEquals(randomUserAccount, putUserAccount);
 		assertValid(putUserAccount);
 
+		Assert.assertNull(putUserAccount.getPermissions());
+
 		UserAccount getUserAccount = userAccountResource.getUserAccount(
 			putUserAccount.getId());
 
 		assertEquals(randomUserAccount, getUserAccount);
 		assertValid(getUserAccount);
+
+		UserAccount randomPermissionsUserAccount =
+			randomPermissionsUserAccount();
+
+		putUserAccount = userAccountResource.putUserAccount(
+			postUserAccount.getId(), randomPermissionsUserAccount);
+
+		assertEquals(randomPermissionsUserAccount, putUserAccount);
+		assertValid(putUserAccount);
+
+		Assert.assertNull(putUserAccount.getPermissions());
+
+		putUserAccount = permissionsUserAccountResource.putUserAccount(
+			postUserAccount.getId(), randomPermissionsUserAccount);
+
+		Assert.assertNotNull(putUserAccount.getPermissions());
 	}
 
 	protected UserAccount testPutUserAccount_addUserAccount() throws Exception {
@@ -6742,12 +6937,35 @@ public abstract class BaseUserAccountResourceTestCase {
 		assertEquals(randomUserAccount, putUserAccount);
 		assertValid(putUserAccount);
 
+		Assert.assertNull(putUserAccount.getPermissions());
+
 		UserAccount getUserAccount =
 			userAccountResource.getUserAccountByExternalReferenceCode(
 				putUserAccount.getExternalReferenceCode());
 
 		assertEquals(randomUserAccount, getUserAccount);
 		assertValid(getUserAccount);
+
+		UserAccount randomPermissionsUserAccount =
+			randomPermissionsUserAccount();
+
+		putUserAccount =
+			userAccountResource.putUserAccountByExternalReferenceCode(
+				postUserAccount.getExternalReferenceCode(),
+				randomPermissionsUserAccount);
+
+		assertEquals(randomPermissionsUserAccount, putUserAccount);
+		assertValid(putUserAccount);
+
+		Assert.assertNull(putUserAccount.getPermissions());
+
+		putUserAccount =
+			permissionsUserAccountResource.
+				putUserAccountByExternalReferenceCode(
+					postUserAccount.getExternalReferenceCode(),
+					randomPermissionsUserAccount);
+
+		Assert.assertNotNull(putUserAccount.getPermissions());
 
 		UserAccount newUserAccount =
 			testPutUserAccountByExternalReferenceCode_createUserAccount();
@@ -6783,6 +7001,50 @@ public abstract class BaseUserAccountResourceTestCase {
 		throws Exception {
 
 		return randomUserAccount();
+	}
+
+	@Test
+	public void testPutUserAccountPermissionsPage() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		UserAccount userAccount =
+			testPutUserAccountPermissionsPage_addUserAccount();
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		assertHttpResponseStatusCode(
+			200,
+			userAccountResource.putUserAccountPermissionsPageHttpResponse(
+				userAccount.getId(),
+				new Permission[] {
+					new Permission() {
+						{
+							setActionIds(new String[] {"VIEW"});
+							setRoleName(role.getName());
+						}
+					}
+				}));
+
+		assertHttpResponseStatusCode(
+			404,
+			userAccountResource.putUserAccountPermissionsPageHttpResponse(
+				0L,
+				new Permission[] {
+					new Permission() {
+						{
+							setActionIds(new String[] {"-"});
+							setRoleName("-");
+						}
+					}
+				}));
+	}
+
+	protected UserAccount testPutUserAccountPermissionsPage_addUserAccount()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -9258,6 +9520,25 @@ public abstract class BaseUserAccountResourceTestCase {
 		return randomUserAccount();
 	}
 
+	protected UserAccount randomPermissionsUserAccount() throws Exception {
+		UserAccount userAccount = randomUserAccount();
+
+		com.liferay.portal.kernel.model.Role role = RoleTestUtil.addRole(
+			RoleConstants.TYPE_REGULAR);
+
+		userAccount.setPermissions(
+			new Permission[] {
+				new Permission() {
+					{
+						setActionIds(new String[] {"VIEW"});
+						setRoleName(role.getName());
+					}
+				}
+			});
+
+		return userAccount;
+	}
+
 	protected final JSONObject waitForFinish(
 			String expectedExecuteStatus, JSONObject jsonObject)
 		throws Exception {
@@ -9283,6 +9564,7 @@ public abstract class BaseUserAccountResourceTestCase {
 	protected UserAccountResource userAccountResource;
 	protected ImportTaskResource importTaskResource;
 	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected UserAccountResource permissionsUserAccountResource;
 	protected com.liferay.portal.kernel.model.Company testCompany;
 	protected com.liferay.portal.kernel.model.Group testGroup;
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/BaseUserAccountResourceTestCase.java
@@ -3689,6 +3689,15 @@ public abstract class BaseUserAccountResourceTestCase {
 
 		Map<String, Map<String, String>> expectedActions = new HashMap<>();
 
+		Map createBatchAction = new HashMap<>();
+		createBatchAction.put("method", "POST");
+		createBatchAction.put(
+			"href",
+			"http://localhost:8080/o/headless-admin-user/v1.0/sites/{siteId}/user-accounts/batch".
+				replace("{siteId}", String.valueOf(siteId)));
+
+		expectedActions.put("createBatch", createBatchAction);
+
 		return expectedActions;
 	}
 
@@ -4031,6 +4040,78 @@ public abstract class BaseUserAccountResourceTestCase {
 		throws Exception {
 
 		return irrelevantGroup.getGroupId();
+	}
+
+	@Test
+	public void testGraphQLGetSiteUserAccountsPage() throws Exception {
+		Long siteId = testGetSiteUserAccountsPage_getSiteId();
+
+		GraphQLField graphQLField = new GraphQLField(
+			"siteUserAccounts",
+			new HashMap<String, Object>() {
+				{
+					put("siteKey", "\"" + siteId + "\"");
+					put("search", null);
+					put("page", 1);
+					put("pageSize", 10);
+				}
+			},
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
+
+		// No namespace
+
+		JSONObject siteUserAccountsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/siteUserAccounts");
+
+		long totalCount = siteUserAccountsJSONObject.getLong("totalCount");
+
+		UserAccount userAccount1 = testGraphQLSiteUserAccount_addUserAccount(
+			siteId, randomUserAccount());
+
+		UserAccount userAccount2 = testGraphQLSiteUserAccount_addUserAccount(
+			siteId, randomUserAccount());
+
+		siteUserAccountsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/siteUserAccounts");
+
+		Assert.assertEquals(
+			totalCount + 2, siteUserAccountsJSONObject.getLong("totalCount"));
+
+		assertContains(
+			userAccount1,
+			Arrays.asList(
+				UserAccountSerDes.toDTOs(
+					siteUserAccountsJSONObject.getString("items"))));
+		assertContains(
+			userAccount2,
+			Arrays.asList(
+				UserAccountSerDes.toDTOs(
+					siteUserAccountsJSONObject.getString("items"))));
+
+		// Using the namespace headlessAdminUser_v1_0
+
+		siteUserAccountsJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(
+				new GraphQLField("headlessAdminUser_v1_0", graphQLField)),
+			"JSONObject/data", "JSONObject/headlessAdminUser_v1_0",
+			"JSONObject/siteUserAccounts");
+
+		Assert.assertEquals(
+			totalCount + 2, siteUserAccountsJSONObject.getLong("totalCount"));
+
+		assertContains(
+			userAccount1,
+			Arrays.asList(
+				UserAccountSerDes.toDTOs(
+					siteUserAccountsJSONObject.getString("items"))));
+		assertContains(
+			userAccount2,
+			Arrays.asList(
+				UserAccountSerDes.toDTOs(
+					siteUserAccountsJSONObject.getString("items"))));
 	}
 
 	@Test
@@ -6823,6 +6904,61 @@ public abstract class BaseUserAccountResourceTestCase {
 	}
 
 	@Test
+	public void testPostSiteUserAccount() throws Exception {
+		UserAccount randomUserAccount = randomUserAccount();
+
+		UserAccount postUserAccount = testPostSiteUserAccount_addUserAccount(
+			randomUserAccount);
+
+		assertEquals(randomUserAccount, postUserAccount);
+		assertValid(postUserAccount);
+
+		UserAccount randomPermissionsUserAccount1 =
+			randomPermissionsUserAccount();
+
+		UserAccount postPermissionsUserAccount1 =
+			testPostSiteUserAccount_addUserAccount(
+				randomPermissionsUserAccount1);
+
+		Assert.assertNull(postPermissionsUserAccount1.getPermissions());
+
+		UserAccount randomPermissionsUserAccount2 =
+			randomPermissionsUserAccount();
+
+		UserAccount postPermissionsUserAccount2 =
+			testPostSiteUserAccount_addPermissionsUserAccount(
+				randomPermissionsUserAccount2);
+
+		Assert.assertNotNull(postPermissionsUserAccount2.getPermissions());
+	}
+
+	protected UserAccount testPostSiteUserAccount_addUserAccount(
+			UserAccount userAccount)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected UserAccount testPostSiteUserAccount_addPermissionsUserAccount(
+			UserAccount userAccount)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLPostSiteUserAccount() throws Exception {
+		UserAccount randomUserAccount = randomUserAccount();
+
+		UserAccount userAccount = testGraphQLSiteUserAccount_addUserAccount(
+			testGroup.getGroupId(), randomUserAccount);
+
+		Assert.assertTrue(equals(randomUserAccount, userAccount));
+	}
+
+	@Test
 	public void testPostUserAccount() throws Exception {
 		UserAccount randomUserAccount = randomUserAccount();
 
@@ -7241,6 +7377,56 @@ public abstract class BaseUserAccountResourceTestCase {
 						},
 						graphQLFields)),
 				"JSONObject/data", "JSONObject/createUserAccount"),
+			UserAccount.class);
+	}
+
+	protected UserAccount testGraphQLSiteUserAccount_addUserAccount()
+		throws Exception {
+
+		return testGraphQLSiteUserAccount_addUserAccount(
+			testGroup.getGroupId(), randomUserAccount());
+	}
+
+	protected UserAccount testGraphQLSiteUserAccount_addUserAccount(
+			Long siteId, UserAccount userAccount)
+		throws Exception {
+
+		JSONDeserializer<UserAccount> jsonDeserializer =
+			JSONFactoryUtil.createJSONDeserializer();
+
+		StringBuilder sb = new StringBuilder("{");
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(UserAccount.class)) {
+
+			if (getGraphQLValue(field.get(userAccount)) != null) {
+				if (sb.length() > 1) {
+					sb.append(", ");
+				}
+
+				sb.append(field.getName());
+				sb.append(": ");
+				sb.append(getGraphQLValue(field.get(userAccount)));
+			}
+		}
+
+		sb.append("}");
+
+		List<GraphQLField> graphQLFields = getGraphQLFields();
+
+		return jsonDeserializer.deserialize(
+			JSONUtil.getValueAsString(
+				invokeGraphQLMutation(
+					new GraphQLField(
+						"createSiteUserAccount",
+						new HashMap<String, Object>() {
+							{
+								put("siteKey", "\"" + siteId + "\"");
+								put("userAccount", sb.toString());
+							}
+						},
+						graphQLFields)),
+				"JSONObject/data", "JSONObject/createSiteUserAccount"),
 			UserAccount.class);
 	}
 

--- a/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/constants/UsersAdminPortletKeys.java
+++ b/modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/constants/UsersAdminPortletKeys.java
@@ -22,6 +22,9 @@ public class UsersAdminPortletKeys {
 	public static final String SERVICE_ACCOUNTS =
 		"com_liferay_users_admin_web_portlet_ServiceAccountsPortlet";
 
+	public static final String USER_ADMIN =
+		"com_liferay_users_admin_web_portlet_UserAdminPortlet";
+
 	public static final String USERS_ADMIN =
 		"com_liferay_users_admin_web_portlet_UsersAdminPortlet";
 

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/UserAdminPortlet.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/UserAdminPortlet.java
@@ -1,0 +1,36 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.users.admin.web.internal.portlet;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.users.admin.constants.UsersAdminPortletKeys;
+
+import jakarta.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Alberto Javier Moreno Lage
+ */
+@Component(
+	property = {
+		"com.liferay.portlet.display-category=category.hidden",
+		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.preferences-unique-per-layout=false",
+		"com.liferay.portlet.private-request-attributes=false",
+		"com.liferay.portlet.private-session-attributes=false",
+		"com.liferay.portlet.use-default-template=true",
+		"jakarta.portlet.display-name=Users",
+		"jakarta.portlet.expiration-cache=0",
+		"jakarta.portlet.name=" + UsersAdminPortletKeys.USER_ADMIN,
+		"jakarta.portlet.resource-bundle=content.Language",
+		"jakarta.portlet.security-role-ref=administrator",
+		"jakarta.portlet.version=4.0"
+	},
+	service = Portlet.class
+)
+public class UserAdminPortlet extends MVCPortlet {
+}


### PR DESCRIPTION
# 🌐 Liferay Devcon 2025 — *Make Your Data Portable*

Welcome to the official repository for the **“Make your data portable”** workshop from **Liferay Devcon 2025**.  
Inside, you'll find everything needed to follow the workshop steps or run the examples directly without changing anything in your local codebase.

---

## 📁 What’s Inside

### 🧭 Workshop Walkthrough  
A **Workshop Walkthrough** directory containing a subfolder for each step of the coding process.  Follow them in order to reproduce the full workflow demonstrated during the session.

### 📦 Preconfigured Bundles  
A set of **bundles with all workshop changes already deployed**.  
Simply download them, update the `liferay.home` property inside `portal-ext.properties` to point to your bundle path, and run the portal directly.

### 📥 Test LAR File  
A **UsersAndPage.lar** file with default data you can import into the portal.  Use it to verify that your Export/Import functionality behaves as expected.

---

## 🚀 Steps to Implement Export/Import for Users  

<details>
<summary><strong>Step 1 - Add new portlet for displaying Users at Export/Import</strong></summary>

To enable the display of "Users" in the Export/Import UI, we first need to register a specific portlet for this purpose.

#### 1. Create the `UserAdminPortlet` class
**File:** `modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/UserAdminPortlet.java`

Create a new `MVCPortlet` with `category.hidden`. This ensures it doesn't appear in the widget menu but acts as the endpoint for the UI.

```java
package com.liferay.users.admin.web.internal.portlet;

import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
import com.liferay.users.admin.constants.UsersAdminPortletKeys;
import jakarta.portlet.Portlet;
import org.osgi.service.component.annotations.Component;

/**
 * @author Alberto Javier Moreno Lage
 */
@Component(
    property = {
        "com.liferay.portlet.display-category=category.hidden",
        "com.liferay.portlet.preferences-owned-by-group=true",
        "com.liferay.portlet.preferences-unique-per-layout=false",
        "com.liferay.portlet.private-request-attributes=false",
        "com.liferay.portlet.private-session-attributes=false",
        "com.liferay.portlet.use-default-template=true",
        "jakarta.portlet.display-name=Users",
        "jakarta.portlet.expiration-cache=0",
        "jakarta.portlet.name=" + UsersAdminPortletKeys.USER_ADMIN,
        "jakarta.portlet.resource-bundle=content.Language",
        "jakarta.portlet.security-role-ref=administrator",
        "jakarta.portlet.version=4.0"
    },
    service = Portlet.class
)
public class UserAdminPortlet extends MVCPortlet {
}

```

#### 2. Add the Portlet Key

**File:** `modules/apps/users-admin/users-admin-api/src/main/java/com/liferay/users/admin/constants/UsersAdminPortletKeys.java`

Register the new portlet key constant so it can be referenced by the component above.

```java
public class UsersAdminPortletKeys {
    
    // ... existing keys ...

    public static final String USER_ADMIN =
        "com_liferay_users_admin_web_portlet_UserAdminPortlet";

    // ... existing keys ...
}

```

</details>

<details>
<summary><strong>Step 2 - Enable export.import.vulcan.batch.engine.task.item.delegate property</strong></summary>

In order to register the proper `BatchEnginePortletDataHandler` for the `UsersAccountsResourceImpl`, we need to add the boolean OSGI property `export.import.vulcan.batch.engine.task.item.delegate` and set it to true.

#### Access the `UsersAccountsResourceImpl` class and change the `@Component` annotation to add the new property.
**File:** `modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java`

```java

//...

/**
 * @author Javier Gamarra
 */
@Component(
	properties = "OSGI-INF/liferay/rest/v1_0/user-account.properties",
	property = {
		"export.import.vulcan.batch.engine.task.item.delegate=true",
		"nested.field.support=true"
	},
	scope = ServiceScope.PROTOTYPE, service = UserAccountResource.class
)
public class UserAccountResourceImpl
//..

```
</details>

<details>
<summary><strong>Step 3 - Implement ExportImportVulcanBatchEngineTaskItemDelegate interface and its methods in UserAccountResourceImpl</strong></summary>

In order to give some more necessary context to the `BatchEnginePortletDataHandler` to handle the Exporting/Importing processes for the entity (in this case `UserAccounts`), we have a Java Interface called `ExportImportVulcanBatchEngineTaskItemDelegate` that we need to implement in each resource that will be used for that purpose.

#### 1. Access the `UsersAccountsResourceImpl` class and add the implementation of the `ExportImportVulcanBatchEngineTaskItemDelegate` interface.
**File:** `modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java`

```java

//...
public class UserAccountResourceImpl
	extends BaseUserAccountResourceImpl
	implements ExportImportVulcanBatchEngineTaskItemDelegate<UserAccount> {

	@Override
//..

```

#### 2.  Implement the abstract `getExportImportDescriptor()` method in `UsersAccountsResourceImpl`.
**File:** `modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java`

```java

//...
				_expandoColumnLocalService, _expandoTableLocalService));
	}

	@Override
	public ExportImportDescriptor getExportImportDescriptor() {
		return new ExportImportDescriptor() {

			@Override
			public String getModelClassName() {
				return User.class.getName();
			}

			@Override
			public String getPortletId() {
				return UsersAdminPortletKeys.USER_ADMIN;
			}

			@Override
			public String getResourceClassName() {
				return UserAccountResource.class.getName();
			}

			@Override
			public Scope getScope() {
				return Scope.SITE;
			}

		};
	}

	@Override
	public UserAccount getMyUserAccount() throws Exception {
//..

```
</details>

<details>
<summary><strong>Step 4 - Add new permission endpoints in rest-openapi.yaml for UserAccounts</strong></summary>

There are a numer of Export/Import functionalities that require some specific implementations at the API layer such as the "Keep permissions" option. REST Builder has some upgraded capabilities in order to simplify this permissions implementation support by doing the following.

#### 1. Add new permissions endpoints for the `UserAccount` entity  at the `rest-openapi.yaml` file following the specific desired pattern
**File:** `modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-config.yaml`

```yaml

#...
            tags: ["Ticket"]
    "/user-accounts/{userAccountId}/permissions":
        get:
            description:
                Retrieves the user account permissions.
            operationId: getUserAccountPermissionsPage
            parameters:
                -   in: path
                    name: userAccountId
                    required: true
                    schema:
                        format: int64
                        type: integer
                -   in: query
                    name: fields
                    schema:
                        type: string
                -   in: query
                    name: restrictFields
                    schema:
                        type: string
                -   in: query
                    name: roleNames
                    schema:
                        type: string
            responses:
                204:
                    content:
                        application/json: {}
                        application/xml: {}
            tags: ["UserAccount"]
        put:
            # @review
            description:
                Overrides the userAccount permissions
            operationId: putUserAccountPermissionsPage
            parameters:
                -   in: path
                    name: userAccountId
                    required: true
                    schema:
                        format: int64
                        type: integer
            requestBody:
                content:
                    application/json: {}
                    application/xml: {}
            responses:
                204:
                    content:
                        application/json: {}
                        application/xml: {}
            tags: ["UserAccount"]
    "/user-accounts/{userAccountId}/phones":
#...

```

#### 2. Set the `generatePermissions` property to true at the `rest-config.yaml` file.
**File:** `modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml`

```yaml

apiDir: ../headless-admin-user-api/src/main/java
apiPackagePath: com.liferay.headless.admin.user
application:
    baseURI: /headless-admin-user
    className: HeadlessAdminUserApplication
    name: Liferay.Headless.Admin.User
author: Javier Gamarra
clientDir: ../headless-admin-user-client/src/main/java
compatibilityVersion: 14
generatePermissions: true
javaEEPackage: jakarta
testDir: ../headless-admin-user-test/src/testIntegration/java

```
</details>

<details>
<summary><strong>Step 5 - BuildREST</strong></summary>

By executing `BuildREST`, the new permissions logic will get autogenerated. This is one of the ways we're simplifying the process of incorporating entities to the Export/Import infrastructure as well as adding Batch support.

#### Access the `modules/apps/headless/headless-admin-user/headless-admin-user-impl` directory through your terminal and execute the `buildRest` gradle task.

```bash
gw buildREST
```
</details>

<details>
<summary><strong>Step 6 - Follow 'doX' pattern (necessary step after `generatePermissions`)</strong></summary>

Previous `GET`/`POST`/`PUT` implementations that are compatible with the nested permissions logic present in the UserAccountResourceImpl need to be migrated to the equivalent protected methods that start with "do".

#### Add "do" before each `GET`/`POST`/`PUT` that has been changed to final by REST Builder and change them from public to protected.
**File:** `modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java`

| Public Method                                   | Protected Method                                         |
|-------------------------------------------------|-----------------------------------------------------------|
| getAccountUserAccountsPage                      | doGetAccountUserAccountsPage                              |
| getOrganizationUserAccountsPage                 | doGetOrganizationUserAccountsPage                         |
| getSiteUserAccountsPage                         | doGetSiteUserAccountsPage                                 |
| getUserAccount                                   | doGetUserAccount                                          |
| getUserAccountByExternalReferenceCode           | doGetUserAccountByExternalReferenceCode                   |
| getUserAccountsPage                              | doGetUserAccountsPage                                     |
| postAccountUserAccount                           | doPostAccountUserAccount                                  |
| postSiteUserAccount                                  | doPostSiteUserAccount                                         |
| postUserAccount                                  | doPostUserAccount                                         |
| putUserAccount                                   | doPutUserAccount                                          |
| putUserAccountByExternalReferenceCode           | doPutUserAccountByExternalReferenceCode                   |

</details>

<details>
<summary><strong>Step 7 - Implement permission checker auxiliary methods</strong></summary>

The autogenerated logic for calculating the permissions require the implementation of some auxiliary methods that exposes necessary data for the `ResourcePermissions` layer.

#### Access `UsersAccountsResourceImpl` and implement this newly added methods.
**File:** `modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java`

```java

//...
	}

	@Override
	protected Long getPermissionCheckerGroupId(Object id) throws Exception {
		User user = _userService.getUserById((Long)id);

		return user.getGroupId();
	}

	@Override
	protected String getPermissionCheckerPortletName(Object id) {
		return "com.liferay.portal.kernel.model.User";
	}

	@Override
	protected String getPermissionCheckerResourceName(Object id) {
		return User.class.getName();
	}

	@Override
	protected void preparePatch(
//..

```
</details>

---

Feel free to explore, tweak, and build on top of these resources—enjoy the workshop!